### PR TITLE
Tables Fixed

### DIFF
--- a/Zero/strange slut.i7x
+++ b/Zero/strange slut.i7x
@@ -382,6 +382,7 @@ When Play begins:
 Table of infection heat (continued)
 infect name	heat cycle	heat duration	trigger text	description text	heat start	heat end	inheat
 --	--	--	--	--	--	--	--
+--	--	--	--	--	--	--	--
 
 When Play begins:
 Choose a blank row from Table of infection heat;


### PR DESCRIPTION
A second blank row was needed for both the monster table and heat table.  Now compiles w/o a runtime error.
