### PR TITLE
Funfeatgain Fix

### DIFF
--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -2518,7 +2518,7 @@ To Combat Menu:
 			wait for any key;
 			try looking;
 			continue the action;
-		say "Choose your action: [line break]";
+		say "Choose your action: A(ttack), I(tem), P(ass), S(ubmit), F(lee)[line break]";
 		repeat through table of basic combat:
 			say "[link][title entry][end link][line break][run paragraph on]";
 		get typed command as playerinput;

--- a/Nuku Valente/Feats.i7x
+++ b/Nuku Valente/Feats.i7x
@@ -24,6 +24,9 @@ Check featgetting:
 		if doctor mouse is not visible, say "You should see Dr Mouse about that." instead;
 
 carry out featgetting:
+	featget;
+
+[
 	blank out the whole of table of gainable feats;
 	repeat with x running through functional featsets:
 		try addfeating x;
@@ -33,6 +36,7 @@ carry out featgetting:
 	otherwise:
 		change the current menu to table of Gainable Feats;
 		carry out the displaying activity;
+]
 
 Featqualified is a number that varies.
 Featqualified is usually 0.
@@ -112,6 +116,7 @@ To FunFeatget:
 			if calcnumber > 0 and calcnumber <= the number of filled rows in table of gainable feats:
 				now current menu selection is calcnumber;
 				follow the gainfeat rule;
+				decrease featgained of player by 1;
 				if featqualified is 0, break;
 			otherwise if playerinput matches "0":	[do not use calcnumber, as non-numbers will return 0]
 				say "Selection aborted.";


### PR DESCRIPTION
This fix will solve the problem with funfeats counting towards the limit of normal feats.

Also, a small clarifier for the fight menu to make it clearer that the first letter can be used.
