### PR TITLE
Researcher/Zephyr Update

### DIFF
--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -1193,7 +1193,7 @@ carry out Inventorying:
 				say "[line break]";
 		if the player is overburdened, say "*OVERBURDENED* ";
 		say "Total Weight: [weight]/[capacity of player] lbs.";
-	if scenario is "Researcher":
+	if scenario is "Researcher" or nanitemeter is 1:
 		say "(You may see your collection of vials using [link][bold type]vial inventory[roman type][end link] or [link][bold type]vint[roman type][end link] for short.)";
 
 understand the command "vint" and "vial inventory" and "vial inv" as something new.
@@ -1206,10 +1206,17 @@ understand "vial inv" as VialInventorying.
 
 carry out VialInventorying:
 	sort vials of player;
+	if scenario is not "Researcher" and nanitemeter is not 1:
+		say "You don't possess anything of that nature.";
+		continue the action;
 	if the number of entries in vials of player is 0:
 		say "Your collection of infection vials is empty.";
 	if the number of entries in vials of player is greater than 0:
-		say "Your infection vial collection consists of:[line break](Type [bold type]vial <name>[roman type] to use a vial without clicking)[line break](type [bold type]vialdrop <name>[roman type] to destroy a vial)[line break]";
+		say "Type [bold type]vial <name>[roman type] to [bold type][bracket]U[close bracket][roman type]se a vial, [bold type]vialdrop <name>[roman type] to [bold type][bracket]D[close bracket][roman type]estroy a vial";
+		if ( scenario is "Researcher" or nanitemeter is 1 ) and Larissa is visible:
+			say " or [bold type]vialsell[roman type] to [bold type][bracket]S[close bracket][roman type]ell a vial";
+		say ".";
+		say "Your infection vial collection consists of:[line break]";
 		let norepeat be a list of text;
 		repeat with x running through vials of player:
 			if x is listed in norepeat, next;
@@ -1219,6 +1226,8 @@ carry out VialInventorying:
 				if z is x, increase count by 1;
 			say "[link][bracket][bold type]U[roman type][close bracket][as]vial [x][end link] ";
 			say "[link][bracket][bold type]D[roman type][close bracket][as]vialdrop [x][end link] ";
+			if ( scenario is "Researcher" or nanitemeter is 1 ) and Larissa is visible:
+				say "[link][bracket][bold type]S[roman type][close bracket][as]vialsell [x][end link] ";
 			say "[X] x [count][line break]";
 
 
@@ -2088,10 +2097,10 @@ To Infect:
 		if there is no name entry:
 			next;
 		break;
-	if scenario is "Researcher" and researchbypass is 0:
-		continue the action;
 	if scenario is "Researcher" or nanite collector is equipped:
 		vialchance name entry;
+	if scenario is "Researcher" and researchbypass is 0:
+		continue the action;
 	let x be a random number from 1 to 5;
 	let bodyparts be { 1, 2, 3, 4, 5 };
 	sort bodyparts in random order;
@@ -2644,9 +2653,7 @@ to win:
 		add loot entry to invent of player;
 	if "Magpie Eyes" is listed in feats of player and lootchance entry is greater than 0:
 		decrease lootchance entry by z;
-	if scenario is "Researcher" and ( a random chance of 1 in 3 succeeds or "Expert Researcher" is listed in feats of player):
-		say "You manage to extract a vial of [name entry] nanites for study and use.";
-		add name entry to vials of player;
+	vialchance (name entry);
 	let reward be lev entry * 2;
 [	if lev entry is greater than 4:
 		now reward is reward * 2;
@@ -2661,9 +2668,18 @@ to win:
 	rule succeeds;
 
 To Vialchance (x - a text):
-	if scenario is "Researcher" and ( a random chance of 1 in 3 succeeds or "Expert Researcher" is listed in feats of player):
-		say "You manage to extract a vial of [x] nanites for study and use.";
-		add x to vials of player;
+	if scenario is "Researcher" or "nanite collector" is listed in Invent of player:
+		let vialcollectible be 10 + ( 2 * intelligence of player );
+		if vialcollectible > 70, now vialcollectible is 70;
+		let vcoll be 0;
+		if a random number between 1 and 100 <= vialcollectible:
+			now vcoll is 1;
+		otherwise if "Expert Researcher" is listed in feats of player and a random number between 1 and 100 <= vialcollectible:
+			now vcoll is 1;
+		if vcoll is 1:
+			say "You manage to extract a vial of [x] nanites for study and use.";
+			add x to vials of player;
+			now vcoll is 0;
 
 
 predestiny is a number that varies.
@@ -3305,6 +3321,7 @@ This is the turnpass rule:
 			if gestation of child is less than 0, now gestation of child is 1;
 	if the humanity of the player is less than 1 and Scenario is not "Researcher":
 		end the game saying "Your mind is lost to the infection.";
+	if the humanity of the player < 1 and scenario is "Researcher", now humanity of player is 1;
 	decrease turns by 1;
 	if ( turns minus targetturns ) is 0 and playon is 0:
 		end the game saying "You survived until the rescue came.";
@@ -4831,7 +4848,7 @@ to say promptsay:
 	if humanity of player is less than 50:
 		say "[link][bracket]UNHINGED[close bracket][as]use journal[end link] ";
 	say "[link][bracket]Inv[close bracket][as]inventory[end link] ";
-	if scenario is "Researcher":
+	if scenario is "Researcher" or nanitemeter is 1:
 		say "[link][bracket]Vial[close bracket][as]Vial Inventory[end link] ";
 	say "[link][bracket]Rest[close bracket][as]rest[end link] ";
 	say "[link][bracket]Save[close bracket][as]saveword[end link] ";

--- a/Nuku Valente/Feats.i7x
+++ b/Nuku Valente/Feats.i7x
@@ -185,8 +185,6 @@ instead of addfeating the fun feats:
 	addfeat "City Map" with "You have better recall of the city layout and remember where most major landmarks are.";
 
 instead of addfeating the basic feats:
-	if scenario is "Researcher":
-		addfeat "Expert Researcher" with "Your expert skills allow you to always get an infection vial from victories.";
 	addfeat "Survivalist" with "You are great at scavenging. When doing such, you get a +4 to finding things.";
 	addfeat "Roughing It" with "You can take a quick nap w/o a cot anywhere... just sleep with one eye open.";
 	if featunlock is 1:	[available after hospital quest]
@@ -225,6 +223,8 @@ instead of addfeating the basic feats:
 	if stamina of player is greater than 14:
 		addfeat "Iron Stomach" with "Your belly has nano resistance! Eating or drinking infectious items fails to change you.";
 		addfeat "Toughened" with "You take less damage than others(-20% damage)";
+	if scenario is "Researcher" and ( intelligence of player > 14 or level of player >= 9 ):
+		addfeat "Expert Researcher" with "Your expert skills allow you a second opportunity to get an infection vial.";
 	if intelligence of player is greater than 14:
 		addfeat "Fast Learner" with "You assimilate new information rapidly. -20% xp needed to level.";
 		addfeat "Expert Medic" with "You are especially good at using medkits, +25% hitpoints restored per use, and a 20% chance of saving a kit when it should be lost.";

--- a/Nuku Valente/Zephyr Inc.i7x
+++ b/Nuku Valente/Zephyr Inc.i7x
@@ -40,13 +40,78 @@ Carry out zephbuying:
 		continue the action;
 	say "You purchase [name entry] for [price entry] creds.";
 	add name entry to invent of player;
+	if name entry is "nanite collector", now nanitemeter is 1;
 	decrease freecred by price entry;
 	decrease score by price entry divided by 5;
-	
+
+understand "vialsell [text]" as vialselling.
+
+Larissa has a list of text called vials.
+
+Vialselling is an action applying to one topic.
+
+check vialselling:
+	if Larissa is not visible, say "There's no one here who's buying." instead;
+
+Carry out vialselling:
+	let basevalue be 0;
+	let t be the topic understood;
+	let target be text;
+	let found be 0;
+	let z be 1;
+	let q be a topic;
+	repeat with x running through vials of player:
+		now q is x;
+		if t in lower case is x in lower case:
+			now target is x;
+			now found is 1;
+			break;
+		increase z by 1;
+	if found is 0:
+		say "You don't seem to have any such vial.";
+		continue the action;
+	say "Pulling out the sample vial, you offer to sell it to Larissa";
+	now found is 0;
+	repeat with x running through vials of Larissa:
+		if t in lower case is x in lower case:
+			increase found by 1;
+			if found > 4:
+				say ", but she shakes her head.  'We have no interest in further samples of that kind.  Try hunting for different game.'";
+				continue the action;
+	[locates target within the table of random critters]
+	now monster is 0;
+	repeat with y running from 1 to number of filled rows in table of random critters:
+		choose row y in table of random critters;
+		if name entry is target:
+			now monster is y;
+			break;
+	if monster is 0:
+		say ", but she shakes her head.  'I'm not really sure where you got that, but it's not on our acquisition list so we can't take it.'";
+		continue the action;
+	choose row monster in table of random critters;
+	now basevalue is ( lev entry * 2 );
+	if found is 1:
+		now basevalue is ( basevalue * 2 ) / 3;
+	otherwise if found > 1:
+		now basevalue is ( basevalue / ( found + 1 ) );
+	if basevalue < 1:
+		say ", but she shakes her head.  'We have met our quota for that sample and have no more interest nanites from [name entry] creatures.  Try hunting for bigger game.'";
+		continue the action;
+	if found is 0:
+		say " and she smiles, taking it from you.  'We were hoping to get one of these samples for your bureau's collection.'  She credits you for [basevalue] freecreds.";
+	otherwise if found is 1:
+		say " and she smiles, taking it from you.  'Thanks for another sample.  I can give you an okay price for that.'  She credits you for [basevalue] freecred(s).";
+	otherwise if found >= 2:
+		say " and she nods, taking it from you.  'We have a few of these already, so I can't pay you as much for more.'  She only credits you with [basevalue] freecred(s) for it.";
+	increase freecred by basevalue;
+	remove entry z from vials of player;
+	add name entry to vials of Larissa;
+
 
 Larissa is a woman. "Manning the counter is a female human with no clear signs of mutation. Her name badge declares her to be 'Larissa'.". She is in Zephyr Lobby.
+The conversation of Larissa is { "We are looking for extracted vial samples.  If you obtain some, please bring it to me to '[bold type]vialsell <name>[roman type]' for a credited reward." }.
 
-The description of Larissa is "She is about five and a half feet, with sun tanned flash. She seems perfectly human, and oddness in this city. Her namebadge, worn on her generous chest, reads 'Larissa'. She had brown straight hair that goes down a little past her shoulders. She wears a lab coat, but it seems more like a uniform than any actual dedication to the sciences. It looks cute on her. Her silver eyes have specks of brown in them, easily seen as she asks how she can help you in a cheerful tone.";
+The description of Larissa is "She is about five and a half feet, with suntanned flesh. She seems perfectly human - an oddness in this city. Her name badge, worn on her generous chest, reads 'Larissa'. She had brown straight hair that goes down a little past her shoulders. She wears a lab coat, but it seems more like a uniform than any actual dedication to the sciences. It certainly looks cute on her though. Her silver eyes have specks of brown in them, easily seen as she asks how she can help you in a cheerful tone.";
 
 Table of Game Objects(continued)
 name	desc	weight	object
@@ -56,10 +121,13 @@ nanite collector is equipment. It is not temporary.
 The placement of it is "body".
 The descmod of it is " A great contraption rests across their back, with many valves and pipes, it looks more like a steampunk jetpack than anything else. Still, it has the Zephyr logo displayed boldly."
 
+nanitemeter is a number that varies.  nanitemeter is normally 0.	[marks if player bought a nanite collector]
+
 Table of Zephyr Goods
 name	price	object	allowed
 "nanite collector"	1000	nanite collector	noresearch rule
 "medkit"	300	medkit	true rule
+[ "pepperspray"	400	pepperspray	true rule	]
 "water bottle"		100	water bottle	true rule
 
 
@@ -68,7 +136,7 @@ This is the true rule:
 	rule succeeds;
 
 This is the noresearch rule:
-	if scenario is "Researcher":
+	if scenario is "Researcher" or nanitemeter is 1:
 		rule fails;
 	rule succeeds;
 


### PR DESCRIPTION
- Vial collection affected by Intelligence.
- Expert Researcher feat grants a second opportunity (Int 15 or level 9)
- Selling vials at progressively decreasing value (maximum of 5 of any given type)
- Vial inventory links only show if vials are available to the player
- The option to see vials appears in the vial inventory if in the presence of Larissa.
