### PR TITLE
fix flat breasts feats bug

### DIFF
--- a/Nuku Valente/Feats.i7x
+++ b/Nuku Valente/Feats.i7x
@@ -143,9 +143,9 @@ instead of addfeating the fun feats:
 	if "Male Preferred" is not listed in feats of player and "Herm Preferred" is not listed in feats of player:
 		addfeat "Female Preferred" with "You will reject male mutation";
 	if "Male Preferred" is listed in feats of player:
-		addfeat "Breasts" with "Despite being all male, you still grow breasts, curious.";
+		if "Flat Chested" is not listed in feats of player, addfeat "Breasts" with "Despite being all male, you still grow breasts, curious.";
 	otherwise:
-		addfeat "Flat Chested" with "Your chest tends to remain flat.";
+		if "Breasts" is not listed in feats of player, addfeat "Flat Chested" with "Your chest tends to remain flat.";
 	if "Female Preferred" is not listed in feats of player and "Male Preferred" is not listed in feats of player:
 		addfeat "Herm Preferred" with "You more easily stay in the wonderful world of dual gendership";
 	if "Modest Organs" is not listed in feats of player or "Passing Grade Chest" is not listed in feats of player:


### PR DESCRIPTION
if you took 'flat chested' before 'male preferred' you could then take 'breasts'
this seemed to be an unintended bug, as opposed to desired feature
added if's which should prevent this
