### PR TITLE
Phase 1 Pewter Consort Implementation

### DIFF
--- a/Blue Bishop/Pewter Consort.i7x
+++ b/Blue Bishop/Pewter Consort.i7x
@@ -1,0 +1,748 @@
+Version 1 of Pewter Consort by Blue Bishop begins here.
+[Version 1 - Phase 1 Implementation of Pewter Consort]
+
+"Adds a Pewter Consort creature to Flexible Survivals Wandering Monsters table"
+
+Section 1 - Monster Responses
+
+consortinsight is a number that varies; [Consort Insight, entails how much the player knows about the Pewter Consort and their perception]
+facecheck is a truth state that varies;
+
+when play begins:
+	add { "Pewter Consort" } to infections of guy;
+	add { "Pewter Consort" } to infections of Tailweapon;
+
+to say losetopewter:
+	if facename of player is "Pewter Consort":
+		now facecheck is true;
+	otherwise:
+		now facecheck is false;
+	if hp of player > 0:
+		say "     You choose to surrender to the lithe assailant, compelling him to back away for a second to assess your action";
+	otherwise:
+		say "     Too exhausted to fight back any further, you fall to your knees, leaving yourself at the assailant's mercy";
+	if a random chance of 1 in 6 succeeds or ("Kinky" is listed in feats of player and a random chance of 1 in 3 succeeds):
+		say ". Pondering what to subject you to for a moment, his maw eventually widens into a bright grin, bouncing up and down with excitement. Circling around to your back, it shoves and nips at you until you're forced to move forward, pushed along down a ruined path by the creature's assertive insistence.";
+		say "     In the distance, you begin to hear cacophony of wanton, muffled sounds, suggesting that the beast intends to subject you to his kin";
+		if hp of player < 1 and player is not submissive:
+			say ". Having recovered slightly, you suddenly attempt to run and avoid what may come to pass. However, the consort is right on your heels, pinning your[if scalevalue of player > 3] larger[end if] form to the ground and compelling you into compliance once more by lashing you with his tail, each sharp, loud smack causing you to tense and writhe. Eventually, he starts compelling you back to your feet and going along again, closer to the sounds.";
+		otherwise:
+			say ". No doubt eager and excited, the consort clearly feels you're moving too slowly, and you're made to jump when the[if scalevalue of player > 3] smaller[end if] creature lashes you with its tail, it's audible smack filling the air, the sting certainly enough motivation for you to pick up the pace.";
+		say "     Once you reach your destination, you see before you [one of]the remnants of a private swimming pool[or]a basement collapsed in on itself, leaving an alcove[or]a hole, carved from the ruins[at random], its contents a writhing, silvery mass of similar creatures, their wanton excess filling what sparse empty space remains with sexual fluids, slicking their dizzying, perpetual motions[if facecheck is true] while your altered vision blinds you with so many colours[end if]. Briefly distracted, the beast that lead you here pushes you forward into the mass, stumbling and falling to meet with the hole's twisted contents.";
+		say "     You're given no chance to react before the monsters respond to their new occupant, gripping and folding along your [bodytype of player] form as they pull you deeper into their depths, the remnant onlooker jumping in along with you. What attire you might've had prior pulled from you and flung from the alcove, you're overwhelmed by the feel of a seemingly countless number of hands and bodies writhing and touching shamelessly over the entirety of your exposed form.";
+		say "     Eventually submerged in flesh, shrouded in [if facecheck is false]darkness[otherwise]a dizzying array of colours[end if], the sensation is overwhelming, and it's clear they're not going to let you go until you break free of them.";
+		wait for any key;
+		if hp of player < 1, now struggleatt is 1;
+		pewterbind;
+	otherwise if anallevel is not 1 and (cunts of player is 0 or anallevel is 3) and (a random chance of 1 in 3 succeeds or (anallevel is 3 and a random chance of 1 in 3 succeeds)):
+		say ". Almost immediately, the creature hops around to find a good angle of approach before immediately pouncing your ass, [if scalevalue of player < 4]pinning[otherwise]forcing[end if] you to the ground and pulling away any obstruction in his path. You'd assume the ensuing grinding of its throbbing rod against your behind is an illustration of the creature's over-eagerness causing him to fumble, but quickly becomes clear that the beast is instead marking you by smearing his precum across your[if scalevalue of player > 3] substantial,[end if] [bodytype of player] cheeks.";
+		say "     This feral foreplay doesn't last particularly long, as he shows just as much eager expedience in shoving his dick past your anal ring, the slick tool slipping its way into your fleshy abyss with zero resistance[if hp of player < 1], much in spite your impotent protests[end if]. A low, approving growl escaping the beast as he revels in the warmth of these supple confines, you feel his long, slick tongue lavish feverish approval on his new fucktoy. Initially asserting his primal ownership with a few firm thrusts, each motion punctuated with a the sound of his balls slapping loudly against your [if cocks of player > 0 and cockname of player is not listed in infections of internallist]own[otherwise]crotch[end if], he braces himself once he's satisfied, the sound of his ensuing thrusts completely filling the air.";
+		say "     [if scalevalue of player < 4]Body rocking against this constant pounding[otherwise]The smaller beast utterly pounding you[end if], he pants and hisses in wanton approval, drooling shamelessly against his plaything as his digits squeeze you more and more tightly. [if hp of player < 1]Unable to resist this persisting assault[otherwise]Overtaken by your own lust[end if], you quickly find yourself aroused as well, [if cocks of player > 0]unattended dick[smn] grinding against the barren earth[otherwise if cunts of player > 0]unattended cunt[sfn] oozing against the open air[otherwise]much in spite your lack of proper outlet[end if]. The beast's motions becoming increasingly erratic in the ensuing minutes, it eventually hisses out in tainted ecstasy, pulling its dick free of you and painting your ass[if scalevalue of player < 4] and back[end if] with successive spurts of his silvery seed";
+		if cocks of player > 0 or cunts of player > 0:
+			if facecheck is true:
+				say ". Feeling his bliss radiate out from him, you can't help but immediately follow suit, [if cocks of player > 0]cock[smn] wasting your [cum load size of player] against the ground[otherwise]cunt[sfn] throbbing against the open air, staining the ground with your sexual fluids[end if], the beast thrusting against you in the moment to ride the waves of your orgasm just a little bit longer.";
+				say "     The creature hisses and licks at you, trembling and utterly spent in the wake of your shared bliss. Eventually, he[ if hp of player < 1] thankfully[end if] recovers enough to pull off you and depart, leaving you a sweat and seed-stained mess. [if showlocale is true]You hear sounds in the distance, no doubt the sordid affair catching some attention, compelling you to gather your things and quickly flee[otherwise]Eventually, you recover enough to gather your things, clean yourself off to the best of your ability, and depart[end if].";
+			otherwise:
+				say ". No doubt a little exhausted, it goes limp against your cum-sullied body, loudly panting as it nonetheless impishly revels in grinding its sweat and now ejaculate-slicked torso against yours.";
+				if waiterhater is 0, wait for any key;
+				say "[line break]";
+				say "     However, the creature doesn't seem quite satisfied with you yet, as once he catches his breath he goes right back to pounding your now fairly loose hole. No doubt he's already quite spent and satisfied, but that doesn't stop him from repeating the same ritual once more, this overly prolonged sex quickly becoming exhausting. Nonetheless, eventually all the stimulation is enough to set you off, [if cocks of player > 0]cock[smn] wasting your [cum load size of player] against the ground[otherwise]cunt[sfn] throbbing against the open air, staining the ground with your sexual fluids[end if].";
+				say "     The creature hisses and licks at you, trembling and utterly overtaken in the wake of your bliss. Eventually, this[ if hp of player < 1] thankfully[end if] seems to be what he was interested in and he finally departs, leaving you a sweat and seed-stained mess. [if showlocale is true]You hear sounds in the distance, no doubt the sordid affair catching some attention, compelling you to gather your things and quickly flee[otherwise]Eventually, you recover enough to gather your things, clean yourself off to the best of your ability, and depart[end if].";
+		otherwise:
+			say "     Appearing somewhat satisfied by making a mess of you, the creature eventually pulls off of you, leaving off into the distance. [if showlocale is true]You hear sounds in the distance, no doubt the sordid affair catching some attention, compelling you to gather your things and quickly flee[otherwise]Eventually, you recover enough to gather your things, clean yourself off to the best of your ability, and move forward[end if].";
+	otherwise if cunts of player > 0 and a random chance of 1 in 2 succeeds:
+		say ". Almost immediately, the creature hops around to find a good angle of approach before immediately pouncing your ass, [if scalevalue of player < 4]pinning[otherwise]forcing[end if] you to the ground and pulling away any obstruction in his path. You'd assume the ensuing grinding of its throbbing rod against your behind is an illustration of the creature's over-eagerness causing him to fumble, but quickly becomes clear that he is instead marking you by smearing his precum across your[if scalevalue of player > 3] substantial,[end if] [bodytype of player] cheeks.";
+		say "     This feral foreplay doesn't last particularly long, and he shows just as much eager expedience in burying his dick into the supple folds of[if cunts of player > 1] one of[end if] your cunt[sfn], the slick tool slipping its way into your eager hole with zero resistance[if hp of player < 1], much in spite your protests[end if]. A low, approving growl as he revels in the warmth of your throbbing confines, you feel his long, slick tongue lavish feverish approval on his new fucktoy. Initially asserting his primal ownership with a few firm thrusts, each motion punctuated with a the sound of his balls slapping loudly against your [if cocks of player > 0 and cockname of player is not listed in infections of internallist]own[otherwise]crotch[end if], he braces himself once he's satisfied, the sound of his ensuing thrusts completely filling the air.";
+		say "     [if scalevalue of player < 4]Body rocking against this constant pounding[otherwise]The smaller beast utterly pounding you[end if], it pants and hisses in wanton approval, drooling shamelessly against its plaything as its digits squeeze you more and more tightly. [if hp of player < 1]Unable to resist this persisting assault[otherwise]Overtaken by your own lust[end if], you quickly find yourself aroused as well, [if cocks of player > 0]unattended dick[smn] grinding against the barren earth[otherwise]stuffed portal squeezing its intrusion needily[end if]. The beast's motions becoming increasingly erratic in the ensuing minutes, he eventually hisses out in tainted ecstasy, pulling his dick free of you and painting your ass[if scalevalue of player < 4] and back[end if] with successive spurts of his silvery seed";
+		if facecheck is true:
+			say ". Feeling his bliss radiate out from him, you can't help but immediately follow suit, [if cocks of player > 0]cock[smn] wasting your [cum load size of player] against the ground[otherwise]used cunt throbbing against the open air, staining the ground with your sexual fluids[end if], the beast thrusting against you in the moment to ride the waves of your orgasm just a little bit longer.";
+			say "     The creature hisses and licks at you, trembling and utterly spent in the wake of your shared bliss. Eventually, he[ if hp of player < 1] thankfully[end if] recovers enough to pull off you and depart, leaving you a sweat and seed-stained mess. [if showlocale is true]You hear sounds in the distance, no doubt the sordid affair catching some attention, compelling you to gather your things and quickly flee[otherwise]Eventually, you recover enough to gather your things, clean yourself off to the best of your ability, and depart[end if].";
+		otherwise:
+			say ". No doubt a little exhausted, it goes limp against your cum-sullied body, loudly panting as it nonetheless impishly revels in grinding its sweat and now ejaculate-slicked torso against yours.";
+			if waiterhater is 0, wait for any key;
+			say "[line break]";
+			say "     However, the creature doesn't seem quite satisfied with you yet, as once he catches his breath he goes [if cunts of player > 2]on to pound one of your previously unused pussies[otherwise if cunts of player is 2]on to pound you previously unused pussy[otherwise]right back to pounding your now fairly loose pussy[end if]. No doubt he's already quite spent and satisfied, but that doesn't stop him from repeating the same ritual once more, this overly prolonged sex quickly becoming exhausting. Nonetheless, eventually all the stimulation is enough to set you off, [if cocks of player > 0]cock[smn] wasting your [cum load size of player] against the ground[otherwise]cunt squeezing greedily around the spent cock[end if].";
+			say "     The creature hisses and licks at you, trembling and utterly overtaken in the wake of your bliss. Eventually, this[ if hp of player < 1] Thankfully[end if] seems to be what he was interested in and he finally departs, leaving you a sweat and seed-soaked mess. [if showlocale is true]You hear sounds in the distance, no doubt the sordid affair catching some attention, compelling you to gather your things and quickly flee[otherwise]Taking a moment to catch your breath, you recover enough to gather your things, clean yourself off to the best of your ability, and move forward[end if].";
+	otherwise:
+		say ". Eagerly, the beast approaches, forcing you down onto all fours before he climbs onto your back, intent on giving you an optimum vantage point of his drooling dick to your face. The throbbing organ staring at you as it is, its apparently quite human, uncut head half exposed from under it's grey, taut foreskin. Eager though he may be, he doesn't see your attendance as an immediate issue, as he seems rather insistent on moving one of your arms to your own[if cocks of player is 0 and cunts of player is 0], genderless[end if] crotch. Clearly, he wants you to please yourself whilst attending to him[if cocks of player is 0 and cunts of player is 0], not that it'll do you much good[end if].";
+		say "     [if hp of player < 1]You're not particularly inclined to humour the beast's insistence, but it doesn't seem interested in progressing until you do so, his infection's influence -- further exacerbated by the scent of his slightly overpowering, male odour -- eventually forcing you to oblige[otherwise]Scent flooded with that of the beast's slightly overpowering, male odor, you ultimately oblige his insistence[end if], free hand [if cocks of player > 1]pumping one of your cocks[otherwise if cocks of player is 1]pumping your cock[otherwise if cunts of player > 1]fondling one of your cunts[otherwise if cunts of player is 1]fondling your cunt[otherwise]fondling you empty groin[end if]. Satisfied, your attention is quickly split when he begins to prod his oozing rod against you, compelled by your rising lust to reciprocate by lavishing it with your tongue's affection, taste quickly flooded with that of the creature's heady precum. On cue, the second he has an opening, he shows no restraint in thrusting his dick into your maw, pounding your pace with his crotch.";
+		say "     The feel of the creature's tongue's slick approval against your back, he begins to pant more loudly, his wanton, reckless fervour compelling you to follow this dizzying descent in line. The wet sound of his persisting motion filling the air for a few short minutes, he eventually pulls his tool free of your mouth's influence, this throbbing organ soon spurting its silvery seed all over your face, ";
+		if cocks of player > 0 or cunts of player > 0:
+			if facecheck is true:
+				say "too overtaken by his radiant lust to do anything but also cry out bliss. [if cocks of player > 0]Spending your [cum load size of player] load all over the ground[otherwise]Feminine portal throbbing achingly against your finger's influence[end if]. The beast can't help but rub his oozing, spent dick against your face as he revels in your ecstasy.";
+			otherwise:
+				say "too trapped in your own lust to do anything but revel in it.";
+				say "     Still furiously attending to yourself, the beast eggs you on by rubbing his oozing, spent dick against your face, eventually forcing you to finally cry out in bliss, [if cocks of player > 0]spending your [cum load size of player] load all over the ground[otherwise]feminine portal throbbing achingly against your finger's influence[end if]. The beast responds by going tense, loudly hissing and growling, as though he too feels your bliss, before finally calming down.";
+		otherwise:
+			say "too [if facecheck is true]overtaken by his radiant[otherwise]trapped in your own[end if] lust to do anything but revel in it.";
+			say "     However, you eventually become too exhausted to continue. The beast doesn't seem particularly satisfied with this, and tries egging you on by rubbing his oozing, spend dick against your face. The whole endeavour proving to be fruitless, he eventually does concede, not pestering you with the matter any further.";
+		say "     Appearing somewhat satisfied by making a mess of you, the creature eventually pulls off of you, leaving you an embarrassing, cum-stained mess. [if showlocale is true]You hear sounds in the distance, no doubt the sordid affair catching some attention, compelling you to gather your things and quickly flee[otherwise]Eventually, you recover enough to gather your things, clean yourself off to the best of your ability, and depart[end if].";
+
+to say beattheconsort:
+	say "     Hissing and growling, it immediately chooses to turn and run the second things turn sour for them, running off into the distance and freeing you to go about your business once more."; [placeholder]
+
+to say pewterdesc:
+	choose row monster from table of random critters;
+	if "Male Preferred" is listed in feats of player:
+		now sex entry is "Male";
+	otherwise if "Female Preferred" is listed in feats of player:
+		now sex entry is "Female";
+	otherwise if "Herm Preferred" is listed in feats of player:
+		now sex entry is "Both";
+	otherwise:
+		now sex entry is "Male";
+	if "Horny Bastard" is listed in feats of player: [lust adjust check]
+		now lustadjust is 1;
+	otherwise if "Cold Fish" is listed in feats of player:
+		now lustadjust is -1;
+	otherwise:
+		now lustadjust is 0;
+	if "Weak Psyche" is listed in feats of player: [psyche adjust check]
+		now psycheadjust is 1;
+	otherwise if "Strong Psyche" is listed in feats of player:
+		now psycheadjust is -1;
+	otherwise:
+		now psycheadjust is 0;
+	say "     Met with the sound of a low, droning growl, you are suddenly beset upon by a peculiar beast. The well-toned quadruped's lean flesh a distinct, faintly metallic gray hue, it's no animal you've ever seen, the alien-looking creature's head utterly devoid of any features save for a toothy, slightly agape, and grinning maw. Slowly circling around you, clearly sizing you up, it's somewhat long and flexible tail sways patiently, and you're soon given a clear view of his apparent arousal, oozing a silvery fluid onto the ground.";
+
+Section 1.1 - Pewter Consort Bind
+
+pewtertorsosuppress is a truth state that varies;
+
+to pewterbind:
+	now lustatt is libido of player;
+	now calcnumber is -1;		
+	let trixieexit be 0;
+	while trixieexit is 0:
+		now boundstate is true;
+		if clearnomore is 0, clear the screen;
+		pewtercapassess;
+		if breast size of player is 0:
+			now pewtertorsosuppress is true;
+		otherwise:
+			now pewtertorsosuppress is false;
+		if pewterheadocc is 0 and pewterbodyocc is 0 and pewtercockocc is 0 and pewtercuntocc is 0 and pewterassocc is 0:
+			pewteroccupyroll;
+		pewterlustapply;
+		increase lustatt by 4 + (lustadjust * 2);
+		decrease humanity of player by 3 + psycheadjust;
+		if lustatt > 99:
+			now tempnum is 1;
+			pewterlustsate;
+			decrease libido of player by (libido of player / 10) + 1;
+			if libido of player < 0, now libido of player is 0;
+			now lustatt is libido of player;
+			if struggleatt > 0, decrease struggleatt by 1;
+			decrease humanity of player by 15 + (psycheadjust * 5);
+			pewterdisengage;
+			if a random chance of 1 in 2 succeeds, pewterdisengage;
+			now tempnum is 0;
+		say "     You are submerged in the writhing flesh of several grey beasts. [one of]You briefly brake the surface, gasping for breath before you're pulled back into the sordid depths[or]The sensation of so much movement all around you is disorienting[or]The thick, masculine odour and the loud groans and gowls of sex are all that floods your senses[at random]. Presently, you're [pewtercharacterassess]. You imagine your only active option is to [bold type]S[roman type]truggle enough until they let you go, lest you [bold type]A[roman type]bide these questionable circumstances.";				
+		[say "     Head: [pewterheadocc] Attend: [pewterheadvar1] Dick: [pewterheadvar2] || Torso: [pewterbodyocc] || Genital: Cock: [pewtercockocc] Attend: [pewtercockvar1] Dick: [pewtercockvar2] | Cunt: [pewtercuntocc] Attend: [pewtercuntvar1] Dick: [pewtercuntvar2] | Ass: [pewterassocc] Attend: [pewterassvar1] Dick: [pewterassvar2][line break]";] [Dev tool]
+		say "[bold type]1[roman type] - [link]Struggle[as]1[end link][line break][run paragraph on]";
+		say "[bold type]2[roman type] - [link]Abide[as]2[end link][line break][run paragraph on]";
+		say "Sanity: [humanity of player]/ 100	Lust: [lustatt]/100	Struggle: [bracket]-[if struggleatt > 1][bold type]X[roman type][otherwise]-[end if][if struggleatt > 0][bold type]X[roman type][otherwise]-[end if][close bracket][line break][run paragraph on]";
+		if humanity of player < 1:
+			now bodyname of player is "Pewter Consort";
+			now facename of player is "Pewter Consort";
+			now tailname of player is "Pewter Consort";
+			now skinname of player is "Pewter Consort";
+			now cockname of player is "Pewter Consort";
+			follow the turnpass rule;
+			now trixieexit is 1;
+		otherwise:
+			let k be 0;
+			now keychar is "INVALID";
+			change the text of the player's command to "";
+			while keychar is "INVALID":
+				now k is the chosen letter;
+				translate k;
+				if the player's command matches "[number]":
+					now keychar is "[number understood]";
+			if keychar in lower case exactly matches the text "s" or keychar in lower case exactly matches the text "1" or keychar in lower case exactly matches the text "return" or keychar in lower case matches the text "struggle":
+				say "[line break]";
+				increase struggleatt by 1;
+				if struggleatt < 3:
+					say "     You deliberately endeavour to free yourself of their hold, [if struggleatt is 1]barely making any progress, as you're quickly pulled back within their slick depths[otherwise]managing to make some headway before being pulled back, just a little bit more..[run paragraph on][end if].";
+					now tempnum is 0;
+					pewterdisengage;
+					if bodyname of player is "Pewter Consort" and player is pure:
+						if a random chance of 1 in 8 succeeds:
+							infect;
+					otherwise if a random chance of 1 in 5 succeeds:
+						infect;
+					wait for any key;
+				otherwise:
+					say "     You finally manage to pull yourself free and climb out of the pool. Crawling away and catching your breath, the lot of them appear too preoccupied with attending to eachother to pursue you, allowing you to gather your things strewn about and get some additional distance. Eventually, you recover enough from the messy and exhausting ordeal to go about your business once more.";
+					now boundstate is false;
+					now pewterbodyocc is 0;
+					now pewterheadocc is 0;
+					now pewtercockocc is 0;
+					now pewterassocc is 0;
+					now pewtercuntocc is 0;
+					now pewterheadvar1 is 0;
+					now pewterheadvar2 is 0;
+					now pewtercockvar1 is 0; 
+					now pewtercockvar2 is 0;
+					now pewtercuntvar1 is 0;
+					now pewtercuntvar2 is 0; 
+					now pewterassvar1 is 0; 
+					now pewterassvar2 is 0; 
+					now struggleatt is 0;
+					now lustatt is 0;
+					now bsextimer is 0;
+					now trixieexit is 1;
+					follow the turnpass rule;
+				next;
+			if keychar in lower case exactly matches the text "a" or keychar in lower case exactly matches the text "2" or keychar in lower case matches the text "abide":
+				say "[line break]";
+				say "     You choose to abide their hold, [one of]hissing and caressing you in approval[or]their continued affection arousing and influencing you further[or]absorbed in the frenzy of flesh and motion[at random].";
+				say "[line break]";
+				pewteroccupyroll;
+				if bodyname of player is "Pewter Consort" and player is pure:
+					if a random chance of 1 in 8 succeeds:
+						infect;
+				otherwise if a random chance of 1 in 5 succeeds:
+					infect;
+				wait for any key;
+				next;
+			say "Invalid action.";
+			
+pewterheadcap is a number that varies; [Dictates, via scale, how many consorts might occupy a body region]
+pewterbodycap is a number that varies;
+pewtergenitalcap is a number that varies;
+pewterheadocc is a number that varies; [Indicates how many consorts are occupying a body region]
+pewterbodyocc is a number that varies;
+pewtercockocc is a number that varies;
+pewtercuntocc is a number that varies;
+pewterassocc is a number that varies;
+pewterheadvar1 is a number that varies; [Indicates how many consorts are attending/tounging a body region]
+pewterheadvar2 is a number that varies; [Indicates how many consorts are riding/fucking a body region]
+pewtercockvar1 is a number that varies; 
+pewtercockvar2 is a number that varies;
+pewtercuntvar1 is a number that varies;
+pewtercuntvar2 is a number that varies; 
+pewterassvar1 is a number that varies; 
+pewterassvar2 is a number that varies; 
+scaledr is a number that varies; [Scale Diminishing Return, ensures larger players aren't completely overwhelmed]
+
+to pewterlustsate:
+	say "     Unable to hold back any longer, you cry out in bliss, ";
+	if cocks of player > 0:
+		if pewtercockocc > 0:
+			if pewtercockocc > 1:
+				if pewtercockvar1 > 0 and pewtercockvar2 > 0:
+					say "[if pewtercockvar1 is 1]one[otherwise][pewtercockvar1][end if] of your dicks firing its [cum load size of player] load into [if pewtercockvar1 > 1]the consorts' attending maws[otherwise]the consort's attending maw[end if], the [if pewtercockvar2 is 1]one other[otherwise][pewtercockvar2] others[end if] unloaded into their rider[if pewtercockvar2 > 1]s[end if]";
+				otherwise if pewtercockvar1 > 0:
+					say "[if pewtercockvar1 is 1]one[otherwise][pewtercockvar1][end if] of your dicks firing its [cum load size of player] load into [if pewtercockvar1 > 1]the consorts' attending maws[otherwise]the consort's attending maw[end if]";
+				otherwise:
+					say "[if pewtercockvar2 is 1]one[otherwise][pewtercockvar2][end if] of your dicks firing its [cum load size of player] load into [if pewtercockvar2 > 1]the consort's eager ass[otherwise]the consort's eager ass[end if]";
+			otherwise:
+				if pewtercockvar1 > 0:
+					say "[if cocks of player > 1]one of your dicks[otherwise]your dick[end if] firing its [cum load size of player] load into the consort's attending maw";
+				otherwise:
+					say "[if cocks of player > 1]one of your dicks[otherwise]your dick[end if] firing its [cum load size of player] load into the consort's eager ass";
+			if cocks of player > pewtercockocc:
+				say ", those unattended further sullying your slick surroundings";
+		otherwise:
+			say "unattended dick[smn] further sullying your slick surroundings";
+	otherwise if cunts of player > 0:
+		if pewtercuntocc > 0:
+			if pewtercuntocc > 1:
+				if cunts of player >= pewtercuntvar1 + pewtercuntvar2:			
+					if pewtercuntvar1 > 0 and pewtercuntvar2 > 0:
+						say "the [if pewtercuntvar1 is 1]one[otherwise][pewtercuntvar1][end if] of your cunts tightening around their invading tongues, as with the [if pewtercockvar2 is 1]one other[otherwise][pewtercockvar2] others[end if] being fucked";
+					otherwise if pewtercuntvar1 > 0:
+						say "the [if pewtercuntvar1 is 1]one[otherwise][pewtercuntvar1][end if] of your cunts tightening around their invading tongues";
+					otherwise:
+						say "the [if pewtercuntvar2 is 1]one[otherwise][pewtercuntvar2][end if] of your cunts tightening around their invading dicks";
+				otherwise:
+					if pewtercuntvar1 > 0 and pewtercuntvar2 > 0:
+						say "your cunt[sfn] tightening around the [if pewtercuntvar1 is 1]one[otherwise][pewtercuntvar1][end if] tounging [if cunts of player > 1]them[otherwise]it[end if], as with the [if pewtercockvar2 is 1]one other[otherwise][pewtercockvar2] others [end if] fucking the doubtlessly strained thing[sfn]";
+					otherwise if pewtercuntvar1 > 0:
+						say "your cunt[sfn] tightening around the [if pewtercuntvar1 is 1]one[otherwise][pewtercuntvar1][end if] tounging [if cunts of player > 1]them[otherwise]it[end if]";
+					otherwise:
+						say "your cunt[sfn] tightening around the [if pewtercuntvar2 is 1]one[otherwise][pewtercuntvar2][end if] fucking [if cunts of player > 1]them[otherwise]it[end if]";
+			otherwise:
+				if pewtercuntvar1 > 0:
+					say "the[if cunts of player > 1] one[end if] cunt tightening around [if pewtercuntvar1 is 1]lone[otherwise][pewtercuntvar1][end if] tonguing it";
+				otherwise:
+					say "the[if cunts of player > 1] one[end if] cunt tightening around [if pewtercuntvar1 is 1]lone[otherwise][pewtercuntvar1][end if] fucking it";
+		otherwise:
+			say "unattended cunt[sfn] aching with overwhelming need.";
+	otherwise:
+		say "causing you to writhe in insatiable bliss";
+	say ". Your own orgasm quickly sparks a cascade of cries and hisses, rippling outward until, in mere seconds, the rest of them begin to fire off. Your surroundings becoming rigid and firm, met with a hot rush of cum ";
+	if pewterheadvar2 > 0:
+		if pewtercuntvar2 > 0 and pewterassvar2 > 0:
+			say "flooding your gullet, cunt[if cunts of player > 1 and pewtercuntvar2 > 1]s[end if], and ass, all at once until it sputters from your beleagured holes";
+		otherwise if pewtercuntvar2 > 0:
+			say "flooding your gullet and cunt[if cunts of player > 1 and pewtercuntvar2 > 1]s[end if] all at once until it sputters from your beleagured holes";
+		otherwise if pewterassvar2 > 0:
+			say "flooding your gullet and ass all at once until it sputters from your beleagured holes";
+		otherwise:
+			say "flooding your gullet[if pewterheadvar2 > 1] all at once until it sputters from your beleagured hole[end if]";
+	otherwise if pewtercuntvar2 > 0:
+		if pewterassvar2 > 0:
+			say "flooding your ass and cunt[if cunts of player > 1 and pewtercuntvar2 > 1]s[end if] all at once until it sputters from your beleagured holes";
+		otherwise:
+			say "flooding your cunt[if cunts of player > 1 and pewtercuntvar2 > 1]s[end if][if pewtercuntvar2 > 1] all at once until it sputters from your beleagured hole[end if][if cunts of player > 1 and pewtercuntvar2 > 1]s[end if]";
+	otherwise if pewterassvar2 > 0:
+		say "flooding your bowels[if pewterassvar2 > 1] all at once until it sputters from your beleaguered hole[end if]";
+	if pewterheadvar2 > 0 or pewtercuntvar2 > 0 or pewterassvar2 > 0:
+		say ", the rest washing over you";
+	otherwise:
+		say "washing over your [bodytype of player] form, utterly drenching you in the sticky mess";
+	say ".";
+	say "     This persists for a few, fairly prolongued long minuets, as when some find bliss they have the effect of making those already-sated find theirs a second time. Eventually, things do calm down, but only so much that the motion returns to the status quo, ";
+	if pewterheadocc + pewterbodyocc + pewtercockocc + pewtercuntocc + pewterassocc > 1:
+		say "your attending consorts returning their primary attention back on you, ";
+	otherwise if pewterheadocc + pewterbodyocc + pewtercockocc + pewtercuntocc + pewterassocc is 1:
+		say "your attending consort returning his primary attention back on you, ";
+	say "there's seemingly no end to their lust!";
+	
+to say pewtercharacterassess:
+	if pewterheadocc is 0 and pewterbodyocc is 0 and pewtercockocc is 0 and pewtercuntocc is 0 and pewterassocc is 0:
+		say "spared of any of their direct attention, though that will likely change very quickly";
+	otherwise:
+		if pewterheadocc > 0:
+			if pewterheadocc is 1:
+				say "made to attend to ";
+				if pewterheadvar1 is 1:
+					say "the embrace of one's lips upon your own, tongue impishly worming around in your maw";
+				otherwise:
+					say "one of the creature's dick lodged firmly in your maw, forcing you to taste its silvery pre";
+			otherwise:
+				say "split between attending ";
+				if pewterheadvar1 is 1 and pewterheadvar2 is 1:
+					say "the tongue of one creature and the dick of another, left only with the taste of silvery pre and saliva";
+				otherwise if pewterheadvar1 is 2:
+					say "the tongue of two creatures, their slick writhing organs tormenting you in unison";
+			if (pewterbodyocc > 0 and pewtercockocc is 0 and pewtercuntocc is 0 and pewterassocc is 0) or (pewterbodyocc is 0 and pewtercockocc > 0 and pewtercuntocc is 0 and pewterassocc is 0) or (pewterbodyocc is 0 and pewtercockocc is 0 and pewtercuntocc > 0 and pewterassocc is 0) or (pewterbodyocc is 0 and pewtercockocc is 0 and pewtercuntocc is 0 and pewterassocc > 0):
+				say " and ";
+			otherwise if pewterbodyocc is 0 and pewtercockocc is 0 and pewtercuntocc is 0 and pewterassocc is 0:
+				say "";
+			otherwise:
+				say ", ";	
+		if pewterbodyocc > 0:
+			if pewtertorsosuppress is true:
+				say "embraced by a consort, its digits slickly caressing your [bodytype of player] form";
+			otherwise:
+				say "suckled upon by [if pewterbodyocc is 1]one[otherwise][pewterbodyocc][end if] upon your teat[if pewterbodyocc > 1]s[end if], feeding and attending you";
+			if (pewtercockocc > 0 and pewtercuntocc is 0 and pewterassocc is 0) or (pewtercockocc is 0 and pewtercuntocc > 0 and pewterassocc is 0) or (pewtercockocc is 0 and pewtercuntocc is 0 and pewterassocc > 0):
+				say ", and ";
+			otherwise if pewtercockocc is 0 and pewtercuntocc is 0 and pewterassocc is 0:
+				say "";
+			otherwise:
+				say ", ";	
+		if pewtercockocc > 0 or pewtercuntocc > 0 or pewterassocc > 0:
+			say "made to writhe as ";
+		if pewtercockocc > 0:
+			if pewtercockocc > 1:
+				if pewtercockvar1 > 0 and pewtercockvar2 > 0:
+					say "[if pewtercockvar1 is 1]one[otherwise][pewtercockvar1][end if] of your dicks are sucked off, [if pewtercockvar2 is 1]one other[otherwise][pewtercockvar2] others[end if] being riden";
+				otherwise if pewtercockvar1 > 0:
+					say "[if pewtercockvar1 is 1]one[otherwise][pewtercockvar1][end if] of your dicks are sucked off";
+				otherwise:
+					say "[if pewtercockvar2 is 1]one[otherwise][pewtercockvar2][end if] of your dicks are being riden";
+			otherwise:
+				if pewtercockvar1 > 0:
+					say "[if cocks of player > 1]one of your dicks are[otherwise]your dick is[end if] sucked off";
+				otherwise:
+					say "[if cocks of player > 1]one of your dicks are[otherwise]your dick is[end if] being riden";
+			if (pewtercuntocc > 0 and pewterassocc is 0) or (pewtercuntocc is 0 and pewterassocc > 0):
+				say ", and ";
+			otherwise if pewtercuntocc is 0 and pewterassocc is 0:
+				say "";
+			otherwise:
+				say ", ";
+		if pewtercuntocc > 0:
+			if pewtercuntocc > 1:
+				if cunts of player >= pewtercuntvar1 + pewtercuntvar2:			
+					if pewtercuntvar1 > 0 and pewtercuntvar2 > 0:
+						say "[if pewtercuntvar1 is 1]one[otherwise][pewtercuntvar1][end if] of your cunts are being tongued, [if pewtercockvar2 is 1]one other[otherwise][pewtercockvar2] others[end if] being fucked";
+					otherwise if pewtercuntvar1 > 0:
+						say "[if pewtercuntvar1 is 1]one[otherwise][pewtercuntvar1][end if] of your cunts are being tongued";
+					otherwise:
+						say "[if pewtercuntvar2 is 1]one[otherwise][pewtercuntvar2][end if] of your cunts are being fucked";
+				otherwise:
+					if pewtercuntvar1 > 0 and pewtercuntvar2 > 0:
+						say "your cunt[if cunts of player > 1]s are[otherwise] is[end if] tongued by [if pewtercuntvar1 is 1]one[otherwise][pewtercuntvar1][end if], fucked by [if pewtercockvar2 is 1]one other[otherwise][pewtercockvar2] others[end if][if cunts of player > 1] as they share your [cunts of player] holes[end if]";
+					otherwise if pewtercuntvar1 > 0:
+						say "your cunt[if cunts of player > 1]s are[otherwise] is[end if] tongued by [if pewtercuntvar1 is 1]one[otherwise][pewtercuntvar1][end if]";
+					otherwise:
+						say "your cunt[if cunts of player > 1]s are[otherwise] is[end if] fucked by [if pewtercuntvar2 is 1]one[otherwise][pewtercuntvar2][end if]";
+			otherwise:
+				if pewtercuntvar1 > 0:
+					say "[if cunts of player > 1]one of [end if]your cunt[sfn] being tongued by [if pewtercuntvar1 is 1]one[otherwise][pewtercuntvar1][end if]";
+				otherwise:
+					say "[if cunts of player > 1]one of [end if]your cunt[sfn] being fucked by [if pewtercuntvar2 is 1]one[otherwise][pewtercuntvar2][end if]";
+			if pewterassocc > 0:
+				say ", and ";
+			otherwise:
+				say "";
+		if pewterassocc > 0:
+			if pewterassocc > 1:
+				if pewterassvar1 > 0 and pewterassvar2 > 0:
+					say "your ass is rimmed by [if pewterassvar1 is 1]one[otherwise][pewterassvar1][end if] of them, [if pewterassvar2 is 1]one other[otherwise][pewterassvar2] others[end if] fucking it";
+				otherwise if pewterassvar1 > 0:
+					say "your ass is rimmed by [pewterassvar1] of them";
+				otherwise:
+					say "your ass is pounded by [pewterassvar2] of them";
+			otherwise:
+				if pewterassvar1 > 0:
+					say "your ass is being rimmed by one of them";
+				otherwise:
+					say "your ass is being pounded by one of them";
+
+to pewtercapassess:
+	if scalevalue of player < 3:
+		now pewterheadcap is 1;
+		now pewterbodycap is 2;
+		now pewtergenitalcap is 2;
+		now scaledr is 3;
+	otherwise if scalevalue of player is 3:
+		now pewterheadcap is 2;
+		now pewterbodycap is 2;
+		now pewtergenitalcap is 3;
+		now scaledr is 3;
+	otherwise if scalevalue of player is 4:
+		now pewterheadcap is 2;
+		now pewterbodycap is 4;
+		now pewtergenitalcap is 3;
+		now scaledr is 2;
+	otherwise:
+		now pewterheadcap is 2;
+		now pewterbodycap is 6;
+		now pewtergenitalcap is 4;
+		now scaledr is 1;
+	if breast size of player is 0, now pewterbodycap is 1;
+		
+to pewteroccupyroll:
+	if pewterheadcap > pewterheadocc and a random chance of 1 in 3 succeeds:
+		pewterheadapply;
+	otherwise if ((pewterbodycap > pewterbodyocc and pewtertorsosuppress is false) or (pewtertorsosuppress is true and pewterbodyocc is 0)) and a random chance of 1 in 2 succeeds:
+		pewterbodyapply;
+	otherwise if pewtergenitalcap > (pewtercockocc + pewtercuntocc + pewterassocc) and a random chance of 2 in 3 succeeds:
+		pewtergenitalapply;
+		
+to pewterheadapply:
+	If a random chance of 1 in 2 succeeds:
+		if pewterheadocc is 0:
+			say "     You feel the lips of one of the consort's against your own, his tongue [if hp of player < 1]pushing its way into[otherwise]flooding[end if] your mouth and [if hp of player < 1]forcing[otherwise]compelling[end if] you to reciprocate.";
+		otherwise if pewterheadvar1 is 1:
+			say "     A second creature comes to seek your tongue's affection, forcing your attention between both it and the other's, their twin, writhing organs quickly overwhelming you.";
+		otherwise:
+			say "     A second creature meets your head, it's tongue worming its way in, forcing your attention between attending him and the other's dick, quickly overwhelming you with a swill of saliva and and silvery precum.";
+		increase pewterheadvar1 by 1;
+	otherwise:
+		if pewterheadocc is 0:
+			say "     You're suddenly forced to contend with the insistent prodding of a consort's dick against your face, eventually [if hp of player < 1]forced[otherwise]compelled[end if] to open your mouth, immediately flooding your maw's confines and force you to taste it's heady, masculine flavour.";
+		otherwise if pewterheadvar2 is 1:
+			say "     A second dick is prodded against your face, forcing your attention between fellating it and the other's, the two oozing tools quickly making you dizzy with their taste and volume.";
+		otherwise:
+			say "     The dick of a second creature meets your head, the oozing organ forcing its way into your maw as it attends to the tongue of the first, quickly overwhelming you with a swill of saliva and and silvery precum.";
+		increase pewterheadvar2 by 1;
+	increase pewterheadocc by 1;
+
+to pewterbodyapply:
+	if pewtertorsosuppress is true:
+		say "     You're met with the firm, cum-slicked caress of a consort's touch against your [bodydesc of player] form, his teasing caress further exacerbating your present arousal.";
+	otherwise:
+		if pewterbodyocc is 0:
+			say "     You feel one of the consort's lips encircle your exposed nipples, teasing and suckling you, sustaining itself with your fluid whilst also teasing and arousing you.";
+		otherwise:
+			say "     Another beast moves to suckle one of your unattended teats, joining the [if pewterbodyocc is 1]one other[otherwise][pewterbodyocc] others[end if] already feasting upon you.";
+	increase pewterbodyocc by 1;
+
+to pewtergenitalapply:
+	if cocks of player > 0 and ((anallevel is not 1 and a random chance of 1 in 2 succeeds) or (cunts of player > 0 and a random chance of 1 in 2 succeeds) or anallevel is 1) and cocks of player > pewtercockocc:
+		if a random chance of 1 in 2 succeeds or cock length of player > 14:
+			if pewtercockocc is 0:
+				say "     You shudder with the sensation of a consort's tongue along the length of[if cocks of player > 1] one of[end if] your [cock size desc of player] dick[smn], his teasing only brief before his lips envelope its head, eager to taste your emergent sexual fluids as he continues to attend you.";
+			otherwise:
+				say "     Another consort moves to suck off ";
+				if cocks of player - (pewtercockvar1 + pewtercockvar2) is 1:
+					say "your lone, unattended dick";
+				otherwise:
+					say "one of your unattended dicks";
+				say ", joining the ";
+				if pewtercockvar1 > 0 and pewtercockvar2 > 0:
+					say "[if pewtercockvar1 is 1]one other[otherwise][pewtercockvar1] others[end if] and the [if pewtercockvar2 is 1]one[otherwise][pewtercockvar2][end if] riding you";
+				otherwise if pewtercockvar1 > 0:
+					say "[if pewtercockvar1 is 1]one other[otherwise][pewtercockvar1] others[end if] attending you";
+				otherwise:
+					say "[if pewtercockvar2 is 1]one[otherwise][pewtercockvar2][end if] riding you";
+				say ", all eager to milk you dry.";
+			increase pewtercockvar1 by 1;
+		otherwise:
+			if pewtercockocc is 0:
+				say "     You writhe with the sensation of a consort's toned ass grinding along the length of[if cocks of player > 1] one of[end if] your [cock size desc of player] dick[smn], his teasing only brief before he shoves its head past his tight anal ring, eager to take their new guest out for a ride.";
+			otherwise:
+				say "     Another consort moves to ride ";
+				if cocks of player - (pewtercockvar1 + pewtercockvar2) is 1:
+					say "your lone, unattended dick";
+				otherwise:
+					say "one of your unattended dicks";
+				say ", joining the ";
+				if pewtercockvar1 > 0 and pewtercockvar2 > 0:
+					say "[if pewtercockvar2 is 1]one other[otherwise][pewtercockvar2] others[end if] and the [if pewtercockvar1 is 1]one[otherwise][pewtercockvar1][end if] sucking you off";
+				otherwise if pewtercockvar2 > 0:
+					say "[if pewtercockvar2 is 1]one other[otherwise][pewtercockvar2] others[end if] taking you";
+				otherwise:
+					say "[if pewtercockvar1 is 1]one[otherwise][pewtercockvar1][end if] sucking you off";
+				say ", all eager to milk you dry.";
+			increase pewtercockvar2 by 1;
+		increase pewtercockocc by 1;
+	otherwise if cunts of player > 0 and ((anallevel is 3 and a random chance of 1 in 2 succeeds) or anallevel is not 3):
+		if a random chance of 1 in 2 succeeds:
+			if pewtercuntocc is 0:
+				say "     You suddenly feel one of the consort's tongue writhe its way past the supple folds of[if cunts of player > 1] one of[end if] your cunt[sfn], worming shamelessly into your tight hole, its motion slicked by the overwhelming prevalence of sexual fluids encompassing you and its saliva.";
+			otherwise:
+				if cunts of player > pewtercuntvar1 + pewtercuntvar2:
+					say "     Another creature joins in on the fun, its tongue forcing its way into ";
+					if cunts of player - (pewtercuntvar1 + pewtercuntvar2) is 1:
+						say "your lone, unattended cunt";
+					otherwise:
+						say "one of your unattended cunts";
+					say ", joining the ";
+					if pewtercuntvar1 > 0 and pewtercuntvar2 > 0:
+						say "[if pewtercuntvar1 is 1]one other[otherwise][pewtercuntvar1] others[end if] and the [if pewtercuntvar2 is 1]one[otherwise][pewtercuntvar2][end if] fucking you";
+					otherwise if pewtercuntvar1 > 0:
+						say "[if pewtercuntvar1 is 1]one other[otherwise][pewtercuntvar1] others[end if] tonguing you";
+					otherwise:
+						say "[if pewtercuntvar2 is 1]one[otherwise][pewtercuntvar2][end if] fucking you";
+					say ", stuffing another of your holes.";
+				otherwise:
+					say "     Another creature joins in on the fun, its tongue forcing its way into[if cunts of player > 1] one of[end if] you're already-stuffed cunt[sfn], joining the ";
+					if pewtercuntvar1 > 0 and pewtercuntvar2 > 0:
+						say "[if pewtercuntvar1 is 1]one other[otherwise][pewtercuntvar1] others[end if] and the [if pewtercuntvar2 is 1]one[otherwise][pewtercuntvar2][end if] fucking you";
+					otherwise if pewtercuntvar1 > 0:
+						say "[if pewtercuntvar1 is 1]one other[otherwise][pewtercuntvar1] others[end if] tonguing you";
+					otherwise:
+						say "[if pewtercuntvar2 is 1]one[otherwise][pewtercuntvar2][end if] fucking you";
+					say ", further putting a strain on your beleaguered hole[sfn].";
+			increase pewtercuntvar1 by 1;
+		otherwise:
+			if pewtercuntocc is 0:
+				say "     You suddenly feel one of the consort's dick squeeze its way past the supple folds of[if cunts of player > 1] one of[end if] your cunt[sfn], thrusting shamelessly into your tight hole, its motion slicked by the overwhelming prevalence of sexual fluids encompassing you.";
+			otherwise:
+				if cunts of player > pewtercuntvar1 + pewtercuntvar2:
+					say "     Another creature joins in on the fun, its cock forcing its way into ";
+					if cunts of player - (pewtercuntvar1 + pewtercuntvar2) is 1:
+						say "your lone, unattended cunt";
+					otherwise:
+						say "one of your unattended cunts";
+					say ", joining the ";
+					if pewtercuntvar1 > 0 and pewtercuntvar2 > 0:
+						say "[if pewtercuntvar2 is 1]one other[otherwise][pewtercuntvar2] others[end if] and the [if pewtercuntvar1 is 1]one[otherwise][pewtercuntvar1][end if] tonguing you";
+					otherwise if pewtercuntvar2 > 0:
+						say "[if pewtercuntvar2 is 1]one other[otherwise][pewtercuntvar2] others[end if] riding you";
+					otherwise:
+						say "[if pewtercuntvar1 is 1]one[otherwise][pewtercuntvar1][end if] tonguing you";
+					say ", stuffing another of your holes.";
+				otherwise:
+					say "     Another creature joins in on the fun, its cock forcing its way into[if cunts of player > 1] one of[end if] you're already-stuffed cunt[sfn], joining the ";
+					if pewtercuntvar1 > 0 and pewtercuntvar2 > 0:
+						say "[if pewtercuntvar2 is 1]one other[otherwise][pewtercuntvar2] others[end if] and the [if pewtercuntvar1 is 1]one[otherwise][pewtercuntvar1][end if] tonguing you";
+					otherwise if pewtercuntvar2 > 0:
+						say "[if pewtercuntvar2 is 1]one other[otherwise][pewtercuntvar2] others[end if] riding you";
+					otherwise:
+						say "[if pewtercuntvar1 is 1]one[otherwise][pewtercuntvar1][end if] tonguing you";
+					say ", further putting a strain on your stuffed hole[sfn].";
+			increase pewtercuntvar2 by 1;
+		increase pewtercuntocc by 1;
+	otherwise:
+		if a random chance of 1 in 2 succeeds and anallevel is not 1:
+			if pewterassocc is 0:
+				say "     You suddenly feel one of the consort's tongue force its way past your anal ring, worming shamelessly into your tight hole, its motion slicked by the overwhelming prevalence of sexual fluids encompassing you and its saliva.";
+			otherwise:
+				say "     Another creature joins in on the fun being had with your tailpipe, squeezing its writhing tongue past the ";
+				if pewterassvar1 > 0 and pewterassvar2 > 0:
+					say "[if pewterassvar1 is 1]one other[otherwise][pewterassvar1] others[end if] and the [if pewterassvar2 is 1]one[otherwise][pewterassvar2][end if] fucking you";
+				otherwise if pewterassvar1 > 0:
+					say "[if pewterassvar1 is 1]one other[otherwise][pewterassvar1] others[end if] attending you";
+				otherwise:
+					say "[if pewterassvar2 is 1]one[otherwise][pewterassvar2][end if] fucking you";
+				say ", further putting a strain on your stuffed hole.";
+			increase pewterassvar1 by 1;
+		otherwise:
+			if pewterassocc is 0:
+				say "     You suddenly feel one of the consort's dick squeeze its way past your anal ring, thrusting shamelessly into your tight hole, its motion slicked by the overwhelming prevalence of sexual fluids encompassing you.";
+			otherwise:
+				say "     Another creature joins in on the fun being had with your tailpipe, squeezing its cock past the ";
+				if pewterassvar1 > 0 and pewterassvar2 > 0:
+					say "[if pewterassvar2 is 1]one other[otherwise][pewterassvar2] others[end if] and the [if pewterassvar1 is 1]one[otherwise][pewterassvar1][end if] tonguing you";
+				otherwise if pewterassvar2 > 0:
+					say "[if pewterassvar2 is 1]one other[otherwise][pewterassvar2] others[end if] riding you";
+				otherwise:
+					say "[if pewterassvar1 is 1]one[otherwise][pewterassvar1][end if] tonguing you";
+				say ", further putting a strain on your stuffed hole.";
+			increase pewterassvar2 by 1;
+		increase pewterassocc by 1;
+
+to pewterlustapply:
+	if pewterheadocc > 0:
+		if pewterheadvar1 > 0:
+			increase lustatt by ((pewterheadvar1 * (scaledr + 1)) + lustadjust);
+		if pewterheadvar2 > 0:
+			increase lustatt by ((pewterheadvar2 * (scaledr + 2)) + (lustadjust * 2));
+	if pewterbodyocc > 0:
+		increase lustatt by ((pewterbodyocc * (scaledr + 2)) + lustadjust);
+	if pewtercockvar1 > 0:
+		increase lustatt by ((pewtercockvar1 * ((scaledr + 1) * 2)) + (lustadjust * 3));
+	if pewtercockvar2 > 0:
+		increase lustatt by ((pewtercockvar2 * ((scaledr + 2) * 2)) + (lustadjust * 3));
+	if pewtercuntvar1 > 0:
+		increase lustatt by ((pewtercuntvar1 * ((scaledr + 1) * 2)) + (lustadjust * 3));
+	if pewtercuntvar2 > 0:
+		increase lustatt by ((pewtercuntvar2 * ((scaledr + 1) * 2)) + (lustadjust * 3));
+	if pewterassvar1 > 0:
+		increase lustatt by ((pewterassvar1 * (scaledr + 3)) + (lustadjust * 2));
+	if pewterassvar2 > 0:
+		increase lustatt by ((pewterassvar2 * (scaledr + 3)) + (lustadjust * 2));
+
+to pewterdisengage:
+	if pewterheadocc > 0 and a random chance of 1 in 4 succeeds:
+		say "     [if tempnum is 1]In the frenzy[otherwise]With some effort[end if], you're jostled free of one of the consorts attending your head.";
+		if pewterheadvar1 > 0 and (pewterheadvar2 is 0 or a random chance of 1 in 2 succeeds):
+			decrease pewterheadvar1 by 1;
+		otherwise:
+			decrease pewterheadvar2 by 1;
+		decrease pewterheadocc by 1;
+	otherwise if pewterbodyocc > 0 and a random chance of 1 in 3 succeeds:
+		say "     [if tempnum is 1]In the frenzy[otherwise]With some effort[end if], you're jostled free of one of the consorts attending your torso.";
+		decrease pewterbodyocc by 1;
+	otherwise if (pewtercockocc + pewtercuntocc + pewterassocc) > 0 and a random chance of 1 in 2 succeeds:
+		if pewtercockocc > 0 and ((pewtercuntocc is 0 and pewterassocc is 0) or (pewtercuntocc is 0 and a random chance of 1 in 2 succeeds) or (pewterassocc is 0 and a random chance of 1 in 2 succeeds) or (pewterassocc > 0 and pewtercuntocc > 0 and a random chance of 1 in 3 succeeds)):
+			say "     [if tempnum is 1]In the frenzy[otherwise]With some effort[end if], you're jostled free of one of the consorts attending your cock.";
+			if pewtercockvar1 > 0 and (pewtercockvar2 is 0 or a random chance of 1 in 2 succeeds):
+				decrease pewtercockvar1 by 1;
+			otherwise:
+				decrease pewtercockvar2 by 1;
+			decrease pewtercockocc by 1;		
+		otherwise if pewtercuntocc > 0 and (pewterassocc is 0 or a random chance of 1 in 2 succeeds):
+			say "     [if tempnum is 1]In the frenzy[otherwise]With some effort[end if], you're jostled free of one of the consorts attending your cunt.";
+			if pewtercuntvar1 > 0 and (pewtercuntvar2 is 0 or a random chance of 1 in 2 succeeds):
+				decrease pewtercuntvar1 by 1;
+			otherwise:
+				decrease pewtercuntvar2 by 1;
+			decrease pewtercuntocc by 1;		
+		otherwise:
+			say "     [if tempnum is 1]In the frenzy[otherwise]With some effort[end if], you're jostled free of one of the consorts attending your ass.";
+			if pewterassvar1 > 0 and (pewterassvar2 is 0 or a random chance of 1 in 2 succeeds):
+				decrease pewterassvar1 by 1;
+			otherwise:
+				decrease pewterassvar2 by 1;
+			decrease pewterassocc by 1;		
+				
+Section 2 - Monster Insertion
+
+Table of random critters (continued)
+name	attack	defeated	victory	desc	face	body	skin	tail	cock	face change	body change	skin change	ass change	cock change	str	dex	sta	per	int	cha	sex	hp	lev	wdam	area	cocks	cock length	cock width	breasts	breast size	male breast size	cunts	cunt length	cunt width	libido	loot	lootchance	scale (number)	body descriptor (text)	type (text)	magic (truth state)	resbypass (truth state)	non-infectious (truth state)	nocturnal (truth state)	altcombat (text)
+--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	-- 	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--	--;
+
+When Play begins:
+	Choose a blank row from Table of random critters;
+	now name entry is "Pewter Consort";
+	now attack entry is "The [one of]beast[or]creature[or]consort[at random] [one of]pounces onto you, lashing and nipping you into submission until you finally pry him off[or]bounds nearby to lash you sharply with its tail, driving you backwards[or]clings onto you in an attempt to pin you to the ground, forcing you to pull yourself free[or]grabs one of your appendages with its tail and stumbles you to the ground, quickly scrambling back to your feet[at random].";
+	now defeated entry is "[beattheconsort]";
+	now victory entry is "[losetopewter]";
+	now desc entry is "[pewterdesc]";
+	now face entry is "featureless save for a toothy maw. Your vision is strangely grayscale, save for the alluring, entrancing hues emitted from other living beings"; 
+	now body entry is "lean and feral in build, though thankfully your forehands retain their articulation";
+	now skin entry is "[consortskinentry]"; 
+	now tail entry is "You are adorned with a lengthy, prehensile tail, which whistles through the air with a lash.";
+	now cock entry is "[one of]normal-looking[or]seemingly human[at random] and uncut";
+	now face change entry is "[consortfacechange]";
+	now body change entry is "the infection takes hold. Tensing up, your body shifts and adjusts to take on the structure of a feral beast, lean and agile. Looking at your forehands, this strain at least gives you fully articulate digits";
+	now skin change entry is "[consortskinchange]";
+	now ass change entry is "a long tail sprouts from it. Fairly strong and prehensile, it sings as it's lashed through the air.";
+	now cock change entry is "it tingles with a strange sensation. Checking it out, it appears to be strangely human, but the change compels it to slightly ooze from its uncut head, your seed taking on a silvery appearance";
+	now str entry is 14; [14]
+	now dex entry is 17; [17]
+	now sta entry is 14; [14]
+	now per entry is 13; [13]
+	now int entry is 13; [13]
+	now cha entry is 8; [8]
+	now sex entry is "Male";
+	now hp entry is 45; [45]
+	now lev entry is 6; [6]
+	now wdam entry is 6; [6]
+	now area entry is "Capitol";
+	now cocks entry is 1;	
+	now cock length entry is 9;	
+	now cock width entry is 6;	
+	now breasts entry is 0;		
+	now breast size entry is 0;	
+	now male breast size entry is 0;    
+	now cunts entry is 0;		
+	now cunt length entry is 0;
+	now cunt width entry is 0;
+	now libido entry is 45;		
+	now loot entry is "";			[ Dropped item, blank for none.  Case sensitive. ]
+	now lootchance entry is 0;		[ Percentage chance of dropping loot, from 0-100. ]
+	now scale entry is 3;	
+	now body descriptor entry is "[one of]lean[or]feral[or]bestial[at random]";	
+	now type entry is "[one of]feral[or]bestial[at random]";	
+	now magic entry is false;		
+	now resbypass entry is false;		
+	now non-infectious entry is false;
+	blank out the nocturnal entry;
+	now altcombat entry is "default";
+	
+to say consortfacechange:
+	if consortinsight is 0:
+		say "the infection overtakes it. All facial features save for your mouth meld into it, ";
+		if boundstate is true:
+			say "your sight going from darkness to an overwhelming wave to vivid colours, your rounded and smooth head fondled by the creatures.";
+		otherwise:
+			say "leaving your sight in utter blackness and compelling you to fondle your rounded and smooth head. In a scant few seconds, your sight returns to you, but the world around you is now desaturated to the point of being almost entirely gray; however, when you look at your hands they shimmer and glow with a shifting cascade of colours.";
+		now consortinsight is 1;
+		say "     From what you can gather, this strain can somehow sense the emotions of a living thing";
+		if boundstate is true:
+			say ". The way it radiates from the writhing bodies surrounding you is overwhelming, making it even more difficult to keep a clear head, exacerbated by the faintly reflective surface of their flesh and their silvery seed";
+			now consortinsight is 2;
+		otherwise:
+			say ". The way it radiates from others is strangely affecting, making it difficult for you not to obsessively fondle your head in idle revels of your own radiance";
+		if skinname of player is "Pewter Consort" and consortinsight is not 2:
+			say ". You find this quickly exacerbated by your faintly metallic skin, which seems to magnify the effect. It takes you a moment to control yourself";
+			now consortinsight is 2;
+	otherwise:
+		say "the infection overtakes it. All facial features save for your mouth meld into it, ";
+		if boundstate is true:
+			say "your sight going from darkness to an overwhelming wave to vivid colours, your rounded and smooth head fondled by the creatures and exposed once more to their strange empathy";
+		otherwise:
+			say "leaving your sight in utter blackness and compelling you to fondle your rounded and smooth head. In a scant few seconds, your sight returns to you, exposing you once more to the strange and empathic senses of these creatures";
+		if skinname of player is "Pewter Consort" and consortinsight is not 2:
+			say ". You find this quickly exacerbated by your faintly metallic skin, which seems to magnify the effect. It takes you a moment to control yourself";
+			now consortinsight is 2;
+
+to say consortskinchange:
+	say "it begins to tingle with the infection's influence. Your skin takes on a gray and faintly metallic appearance, shimmering in the light";
+	if facename of player is "Pewter Consort" and consortinsight is not 2:
+		say ". You're nearly taken aback by how much this appears to exacerbate your peculiar sense of sight, suggesting that reflective surfaces magnify your senses somehow";
+		now consortinsight is 2;
+
+to say consortskinentry:
+	if facename of player is "Pewter Consort":
+		say "faintly metallic, sensory amplifying";
+	otherwise:
+		say "gray, faintly metallic";
+
+Section 3 - Endings
+
+when play ends:
+	if bodyname of player is "Pewter Consort":
+		if humanity of player is less than 10:
+			if boundstate is true:
+				say "     Unable to retain your humanity after being subjected to this perpetual orgy, it eventually becomes all you know, subjected to a seemingly endless cascade of colours and sensation in an almost hypnotic fashion, seemingly sustained by their collective radiance and their sexual fluids. You never manage to leave and observe the fate of the world outside, but at this point it seems of little issue to you...";
+			otherwise:
+				say "     Overtaken by your infection's control, you lose track of all prior thought, relegating yourself to aimlessly wandering the streets in search of company. Eventually, you find someone to revel with in their warmth. They seem to really enjoy playing hide and seek, but when you finally catch them, it's naught but a few moments of roughhousing before you can make them moan and writhe until they wholly radiate bliss.";
+				say "     After playing this game with them a number of times, they grow inclined to join you on your little adventure, eager to find others to play with as much as you…";
+		otherwise:
+			say "     Your feral, slender body doesn't seem to be regarded very highly by the uninfected, once the military finds and processes you. Once you're inevitably let free back into civilized society, it's a bit hard to maneuver in a world that only ever looks down upon you--both figuratively and literally--but you eventually manage to get by.";
+	if facename of player is "Pewter Consort" and humanity of player > 9:
+		say "     People are particularly detracted by your seemingly alien, eyeless head, but it eventually proves itself to be somewhat advantageous once you become more accustomed to it and what certain colours mean. You gain a fair measure of coin on the side acting as a lie detector, and it certainly makes your more wanton misadventures all the more exciting.";
+				
+Pewter Consort ends here.

--- a/Blue Bishop/Sierrasaur.i7x
+++ b/Blue Bishop/Sierrasaur.i7x
@@ -12,7 +12,7 @@ sierramale is a truth state that varies. sierramale is usually false; [A trigger
 lustatt is a number that varies. lustatt is usually 0;
 struggleatt is a number that varies. struggleatt is usually 0;
 bsextimer is a number that varies. bsextimer is usually 0;
-vorestate is a truth state that varies. vorestate is usually false;
+boundstate is a truth state that varies. boundstate is usually false;
 voreloss is a truth state that varies. voreloss is usually false;
 psycheadjust is a number that varies. psycheadjust is usually 0;
 lustadjust is a number that varies. lustadjust is usually 0;
@@ -32,7 +32,7 @@ to say losetosierra:
 			now struggleatt is 0;
 		wait for any key;
 		now bsextimer is 5;
-		now vorestate is true;
+		now boundstate is true;
 		sierrabind;
 	otherwise:
 		sierrasex;
@@ -53,7 +53,7 @@ to sierrabind:
 			if libido of player < 0, now libido of player is 0;
 			now lustatt is libido of player;
 			if struggleatt > 0, decrease struggleatt by 1;
-			if vorestate is true, decrease humanity of player by 15 + (psycheadjust * 5);
+			if boundstate is true, decrease humanity of player by 15 + (psycheadjust * 5);
 		if a random chance of 4 in 5 succeeds:
 			increase hunger of player by 1;
 			increase thirst of player by 2;
@@ -111,7 +111,7 @@ to sierrabind:
 						wait for any key;
 				otherwise:
 					say "     Finally successful, you're met with the low hacking sound from the beast. Apparently, it wants to relinquish you from you confines, as his firm stomach squeezes you back from whence you came, up through its gullet and out, foot by foot, into the dry, cool open air, made to wallow in a puddle of saliva. Finally having had enough of your fussing, it turns to slowly depart, leaving you to gather your things and go about your business freely once more.";
-					now vorestate is false;
+					now boundstate is false;
 					now struggleatt is 0;
 					now lustatt is 0;
 					now bsextimer is 0;
@@ -149,39 +149,39 @@ to sierrabind:
 			say "Invalid action.";
 
 to sierrasex:
-	if vorestate is true:
+	if boundstate is true:
 		say "     You're confines tremble as the beast starts to make a low hacking sound. Intent on relinquishing you from your confines, its firm stomach squeezes you back from whence you came, up through its gullet and out, foot by foot, into the dry, cool open air. Made to briefly wallow in a puddle of saliva, the creature is clearly not interested in letting you go, pinning you to the ground.";
 	if sierramem is 1:
-		say "     Having a clearer view of the reptile's underside, [if sierramale is true]you're exposed to their previously obscured genitalia[otherwise]it appears to be some manner of hermaphrodite[end if]. Large, blunt-headed and fairly rounded cock bobbing subtly before you, you quickly get the impression that this tool is never not hard, even as you don’t get the impression it’s particularly aroused at this moment. It’s base acts the starting point to a fairly defined, taut cleft, appearing to be a firm and unyielding [if sierramale is true]anal cloaca[otherwise]bestial vent of a cunt[end if].";
+		say "     Having a clearer view of the reptile's underside, [if sierramale is true]you're exposed to their previously obscured genitalia[otherwise]it appears to be some manner of hermaphrodite[end if]. Large, blunt-headed and fairly rounded cock bobbing subtly before you, you quickly get the impression that this tool is never not hard, even as you don't get the impression it's particularly aroused at this moment. It's base acts the starting point to a fairly defined, taut cleft, appearing to be a firm and unyielding [if sierramale is true]anal cloaca[otherwise]bestial vent of a cunt[end if].";
 		now sierramem is 2;
-	if cunts of player > 0 and cunt length of player > 5 and ((vorestate is true and a random chance of 1 in 8 succeeds) or (vorestate is false and a random chance of 1 in 6 succeeds)):
+	if cunts of player > 0 and cunt length of player > 5 and ((boundstate is true and a random chance of 1 in 8 succeeds) or (boundstate is false and a random chance of 1 in 6 succeeds)):
 		say "       Not particularly graceful in its motion, it shamelessly prods your exposed cunt with its rock-hard dick. [if hp of player < 1]Not particularly inclined to be on the receiving end of it, you deliberately make it difficult for the creature to progress, which only forces it to lay on top of you, pinning you down before shoving[otherwise]Once it gets it aim right, it shoves[end if] its tool past your supple folds. [if sierrapure is true]Fairly rough the organ may be, your similar strain is resilient enough to only make it more pleasurable for you[otherwise]Considering how rough and unyielding the organ is, this is a fairly uncomfortable ordeal until its eventually luburicated by its copious precum[end if][if cocks of player > 0], cock[smn] soon driven to attention as well[otherwise if cunts of player > 2], unattended cunts soon aching with need as well[otherwise if cunts of player is 2], unattended cunt soon aching with need as well[end if], forcing a moan free from your lips.";
 		increase lustatt by 45 + (lustadjust * 10);
 		say "      It's initial thrusts are slow and ponderous, though this is of only slightly assuaging since it plows you with its entire length with each motion. As it gradually picks up pace, you visibly being to rock against the beast's motion, the air filling with the sounds of wet, irreverent slapping as it pounds your hole with a deliberate pace. It clearly finds bliss when that same motion briefly becomes erratic and opts to conclude by hilting the organ last time";
-		if (libido of player > 49 and vorestate is false) or lustatt > 99:
+		if (libido of player > 49 and boundstate is false) or lustatt > 99:
 			say ". The force is more than enough to make you find ecstasy as well [if cocks of player > 0]cock[smn] staining the ground and your torso with your [cum load size of player] payload[otherwise]feminine portal eagerly tightening around its firm invader[end if], with little regard by the reptile.";
 			decrease libido of player by (libido of player / 10);
 			if libido of player < 0, now libido of player is 0;
 			now lustatt is libido of player;
 			if struggleatt > 0, decrease struggleatt by 1;
-			if vorestate is true, decrease humanity of player by 15 + (psycheadjust * 5);
+			if boundstate is true, decrease humanity of player by 15 + (psycheadjust * 5);
 		otherwise:
 			say ". Causing your [if cocks of player > 0]cock[smn] to ooze meekly[otherwise]feminine meekly tightening around its firm invader[end if] in insufficient orgasm, with little regard by the reptile.";
-		say "     Assailed with a flood the beast's virile seed[if vorestate is true] -- the volume of which more substantive than what you guess is normal --[otherwise],[end if] [if hp of player < 1]struggling impotently under its hold[otherwise if sierrapure is true]eager to be filled to brim by your larger kin's seed[otherwise]filling your womb to the very brim[end if][if sierrapure is false and scalevalue of player < 4], quickly sputtering from your hole[end if]. [if vorestate is true and sierrapure is true]Clearly, it's used this opportunity to also sustain its twisted offspring[otherwise if vorestate is true]The way it feels being pumped full of that slick fluid, you can guess that this was an excuse to sustain you[otherwise]Oddly enough, being pumped full of that slick fluid has an oddly filling and satisfying effect on you, from what you can feel[end if]. The loud, wet sound of the beast pulling his still-hard dick from your hole, a trail of cum in its wake. [impregchance][line break]";
+		say "     Assailed with a flood the beast's virile seed[if boundstate is true] -- the volume of which more substantive than what you guess is normal --[otherwise],[end if] [if hp of player < 1]struggling impotently under its hold[otherwise if sierrapure is true]eager to be filled to brim by your larger kin's seed[otherwise]filling your womb to the very brim[end if][if sierrapure is false and scalevalue of player < 4], quickly sputtering from your hole[end if]. [if boundstate is true and sierrapure is true]Clearly, it's used this opportunity to also sustain its twisted offspring[otherwise if boundstate is true]The way it feels being pumped full of that slick fluid, you can guess that this was an excuse to sustain you[otherwise]Oddly enough, being pumped full of that slick fluid has an oddly filling and satisfying effect on you, from what you can feel[end if]. The loud, wet sound of the beast pulling his still-hard dick from your hole, a trail of cum in its wake. [impregchance][line break]";
 	otherwise if anallevel is not 1 and (cunts of player is 0 or anallevel is 3) and a random chance of 1 in 8 succeeds:
 		say "     Not particularly graceful in its motion, it shamelessly prods your exposed asshole with its rock-hard dick. [if hp of player < 1]Not particularly inclined to be on the receiving end of it, you deliberately make it difficult for the creature to progress, which only forces it to lay on top of you, pinning you down before shoving[otherwise]Once it gets it aim right, it shoves[end if] its tool past your anal ring. [if sierrapure is true]Fairly rough the organ may be, your similar strain is resilient enough to only make it more pleasurable for you[otherwise]Considering how rough and unyielding the organ is, this is a fairly uncomfortable ordeal until its eventually luburicated by its copious precum[end if][if cocks of player > 0], cock[smn] soon driven to attention as well[otherwise if cunts of player > 0], unattended cunt[sfn] soon aching with need as well[end if], forcing a moan free from your lips.";
 		say "     It's initial thrusts are slow and ponderous, though this is only slightly assuaging since it plows you with its entire length with each motion. As it gradually picks up pace, you visibly begin to rock against the beast's motion, the air filling with the sounds of wet, irreverent slapping as it pounds your hole with a deliberate pace. It clearly finds bliss when that same motion briefly becomes erratic and opts to conclude by hilting the organ last time";
 		increase lustatt by 35 + (lustadjust * 10);
-		if (libido of player > 49 and vorestate is false) or lustatt > 99:
+		if (libido of player > 49 and boundstate is false) or lustatt > 99:
 			say ". The force is more than enough to make you find[if cocks of player is 0 and cunts of player is 0] paltry[end if] ecstasy as well [if cocks of player > 0]cock[smn] staining the ground and your torso with your [cum load size of player] payload[otherwise if cunts of player > 0]neglected, feminine portal[sfn] gushing against the open air[otherwise]supple hole eagerly tightening around its firm invader[end if], with little regard by the reptile.";
 			decrease libido of player by (libido of player / 10);
 			if libido of player < 0, now libido of player is 0;
 			now lustatt is libido of player;
 			if struggleatt > 0, decrease struggleatt by 1;
-			if vorestate is true, decrease humanity of player by 15 + (psycheadjust * 5);
+			if boundstate is true, decrease humanity of player by 15 + (psycheadjust * 5);
 		otherwise:
 			say ". Causing your [if cocks of player > 0]cock[smn] to ooze meekly[otherwise]neglected, feminine portal[sfn] to ooze meekly[otherwise]supple hole to meekly squeeze around its firm invader[end if] in insufficient orgasm, with little regard by the reptile.";
-		say "     Assailed with a flood the beast's virile seed[if vorestate is true] -- the volume of which more substantive than what you guess is normal --[otherwise],[end if] [if hp of player < 1]struggling impotently under its hold[otherwise if sierrapure is true]Eager to be filled to brim by your larger kin's seed[otherwise]filling your bowels to the very brim[end if][if sierrapure is false and scalevalue of player < 4], quickly sputtering from your hole[end if]. [if vorestate is true and sierrapure is true]Clearly, it's used this opportunity to also sustain its twisted offspring[otherwise if vorestate is true]The way it feels being pumped full of that slick fluid, you can guess that this was an excuse to sustain you[otherwise]Oddly enough, being pumped full of that slick fluid has an oddly filling and satisfying effect on you, from what you can feel[end if]. The loud, wet sound of the beast pulling his still-hard dick from your hole, a trail of cum in its wake. [mimpregchance] [line break]";
+		say "     Assailed with a flood the beast's virile seed[if boundstate is true] -- the volume of which more substantive than what you guess is normal --[otherwise],[end if] [if hp of player < 1]struggling impotently under its hold[otherwise if sierrapure is true]Eager to be filled to brim by your larger kin's seed[otherwise]filling your bowels to the very brim[end if][if sierrapure is false and scalevalue of player < 4], quickly sputtering from your hole[end if]. [if boundstate is true and sierrapure is true]Clearly, it's used this opportunity to also sustain its twisted offspring[otherwise if boundstate is true]The way it feels being pumped full of that slick fluid, you can guess that this was an excuse to sustain you[otherwise]Oddly enough, being pumped full of that slick fluid has an oddly filling and satisfying effect on you, from what you can feel[end if]. The loud, wet sound of the beast pulling his still-hard dick from your hole, a trail of cum in its wake. [mimpregchance] [line break]";
 	otherwise if anallevel is 1 and cocks of player > 1 and a random chance of 1 in 8 succeeds and sierramale is false:
 		say "     [if scalevalue of player < 4]Nearly banging you in the head with that perpetually-erect dick, i[otherwise]I[end if]t's not particularly graceful as it moves forward to position its slit over your crotch. Descending to slowly grind against your [cock size desc of player] dick[smn], [if hp of player < 1]you're not exactly in the mood for this sort of crude foreplay, but when you try to struggle free it just pins you down and continues grinding until you're finally compelled into arousal[otherwise if sierrapure is true]your infection strain makes you already pretty hard as it is, and as such it doesn't take much work to render you fully aroused[otherwise]the fairly crude foreplay eventually does compel you into arousal[end if], raising only to slowly sink back down,[if cocks of player > 1] one of[end if] your tool[smn] now between its lips.";
 		say "     The taut cleft is definitely not all that yielding to any sort of intrusion, [if sierrapure is true]though your strain makes you equally as firm, allowing you to impale it with fair ease[otherwise]subjecting you to a fair bit of duress before the finally part to abide your length[end if], the inner walls only marginally softer on you. Not given much in the way of lubrication, the beast only eases you into the matter by first attempting to engulf the entirety of its length[if cock length of player > 14], A feat not particularly easy given your size[end if]";
@@ -190,53 +190,53 @@ to sierrasex:
 		otherwise:
 			say ". With little work, your tool disappears into its depths[if cockname of player is listed in infections of knotlist], knot included[end if]. Shifting slightly, it appears to brace itself for what is to follow.";
 		say "    You guess that it used this to know exactly how long you were, because it immediately raises its crotch just high enough that only a portion of your head remains engulfed, before bearing down firmly once more. It gradually builds a motion of repeating this very deliberate and forceful act, the motion quickly slicked with your pre and the beast's emergent sexual fluids, which oozes down to stain your crotch. [if hp of player < 1]This ritual isn't particularly pleasing to you, but its persistence eventually starts to get to you[otherwise if sierrapure is true]Built exactly for this use[otherwise]The ritual quickly having an effect on you[end if], the weight of its wanton assault eventually squeezes a moan out of your lips, drowned out by the set sound of its sex shamelessly slapping against you, moving you with each descent.";
-		say "    It doesn't take long, but eventually the reptile lets out a strained groan, hilting your dick one last time[if cockname of player is listed in infections of knotlist and cock length of player > 14], this time tying with you proper[end if] before the taut abyss squeezes relentless against your tool, its own dick dribbling out a bit of seed, though the fluid release is easily eclipsed by that of its greedy cunt, gushing substantially to stain your torso[if vorestate is true], in fact, more than you'd guess is normal[end if]";
+		say "    It doesn't take long, but eventually the reptile lets out a strained groan, hilting your dick one last time[if cockname of player is listed in infections of knotlist and cock length of player > 14], this time tying with you proper[end if] before the taut abyss squeezes relentless against your tool, its own dick dribbling out a bit of seed, though the fluid release is easily eclipsed by that of its greedy cunt, gushing substantially to stain your torso[if boundstate is true], in fact, more than you'd guess is normal[end if]";
 		increase lustatt by 50 + (lustadjust * 10);
-		if (libido of player > 49 and vorestate is false) or lustatt > 99:
+		if (libido of player > 49 and boundstate is false) or lustatt > 99:
 			say ". This is more than enough to bring you over the edge, spurting your [cum load size of player] cum into the reptile's depths[if cocks of player > 2], its brothers staining the both of you[otherwise if cocks of player is 2], its brother staining the both of you[end if]. [if cock width of player > 20]It groans slightly, with how much it's forced to abide, but it does manage to take it all with not much issue[otherwise]It barely seems to notice you firing into its depths[end if]";
 			decrease libido of player by (libido of player / 10);
 			if libido of player < 0, now libido of player is 0;
 			now lustatt is libido of player;
 			if struggleatt > 0, decrease struggleatt by 1;
-			if vorestate is true, decrease humanity of player by 15 + (psycheadjust * 5);
+			if boundstate is true, decrease humanity of player by 15 + (psycheadjust * 5);
 		otherwise:
 			say ". Causing your cock to spurt weakly into the beast's tight depths, the reptile not seeming all that interested in getting you off properly and subsequently leaving you still lust-addled";
-		say ". [if sierrapure is true and vorestate is true]Clearly, your larger kin wishes to bathe its smaller occupant, making you awash in its rejuvenating effects[otherwise if vorestate is true and sierramem is 2]The sexual fluids seem to have a rejuvenating effect as the wash over you, clearly indicating that it used this act to sustain its prisoner[otherwise if sierramem is 2]Oddly, the sexual fluids feel a bit rejuvenating when partially coated in it[otherwise if vorestate is true]Bathing you in its sexual fluids, it gives its prisoner a moment to bask in its rejuvinating effects[otherwise]Bathing you in its sexual fluids, it gives you a moment to bask in its rejuvinating effects[end if]. Finally satisfied, it pulls itself free of you, the loud, wet sound of its departure filling the air briefly.";
+		say ". [if sierrapure is true and boundstate is true]Clearly, your larger kin wishes to bathe its smaller occupant, making you awash in its rejuvenating effects[otherwise if boundstate is true and sierramem is 2]The sexual fluids seem to have a rejuvenating effect as the wash over you, clearly indicating that it used this act to sustain its prisoner[otherwise if sierramem is 2]Oddly, the sexual fluids feel a bit rejuvenating when partially coated in it[otherwise if boundstate is true]Bathing you in its sexual fluids, it gives its prisoner a moment to bask in its rejuvinating effects[otherwise]Bathing you in its sexual fluids, it gives you a moment to bask in its rejuvinating effects[end if]. Finally satisfied, it pulls itself free of you, the loud, wet sound of its departure filling the air briefly.";
 		if sierramem is 2, now sierramem is 3;
 	otherwise: [Oral -- Should be most prominent]
-		say "     Climbing on top of you clear lack of expedience, it shows no restrain in prodding your face with its perpetually hard dick, [if vorestate is true and sierrapure is true]the reptile eager to feed it's juvenile kin through its[otherwise if vorestate is true]you get the impression that the reptile feels it needs to compensate for draining you by forcing you to feed from its[otherwise]clearly it expects you to satisfy the reptile's[end if] lewd pipe. [if hp of player < 1]You try to resist, at first, but this only compels it to be more insistent pinning you down firmly until you cry out in obligation[otherwise]Only briefly reluctant[end if], your maw enveloping the tool's blunt head. Quite firm against your lips, it nonetheless oozes precum almost immediately, even your brief affection amplifying the release of these fluids with considerable expedience.";
+		say "     Climbing on top of you clear lack of expedience, it shows no restrain in prodding your face with its perpetually hard dick, [if boundstate is true and sierrapure is true]the reptile eager to feed it's juvenile kin through its[otherwise if boundstate is true]you get the impression that the reptile feels it needs to compensate for draining you by forcing you to feed from its[otherwise]clearly it expects you to satisfy the reptile's[end if] lewd pipe. [if hp of player < 1]You try to resist, at first, but this only compels it to be more insistent pinning you down firmly until you cry out in obligation[otherwise]Only briefly reluctant[end if], your maw enveloping the tool's blunt head. Quite firm against your lips, it nonetheless oozes precum almost immediately, even your brief affection amplifying the release of these fluids with considerable expedience.";
 		say "     The creature insisting on forcing it deeper into you ";
 		if facename of player is "Sierrasaur":
 			say "-- not that your wide-set maw can't handle it --";
 		otherwise:
 			say "your ability to breath is considerably limited,";
-		say " [if vorestate is true]though he relents just enough to not overwhelm you, [end if]making you rapidly swallow down his sexual fluids just to keep up. This ritual [if hp of player < 1]forcibly[otherwise]quickly[end if] [if cocks of player > 0]drives your dick[smn] erect, throbbing in the open air[otherwise if cunts of player > 0]makes you cunt[sfn] ache with an overwhelming need[otherwise]makes you aroused, though you have no way of sating it[end if], a matter you're too preoccupied right now to properly attend to, as the beast thrusts instinctively against your attending hole.";
-		say "    With a low, loud groan, the reptile [if vorestate is true]suddenly pins you down, forcing almost the entire length down your throat. flooding[otherwise]floods[end if] your gullet with its thick, creamy fluid. [if vorestate is true and sierrapure is true]The creature is happy to feed its little companion, generating a fair amount more than what is normal for it, probably also using this time to train you, as your torso bloats to abide the overwhelming flood[otherwise if vorestate is true]The creature is dead set on forcing you to swallow all of it down, and it's quickly clear that it seems to be generating more than usual, your stomach quickly bloating to abide this overwhelming flood[otherwise if sierrapure is true]The creature is happy to feed its little companion, flooding your belly with its virile seed[otherwise]The flood is so substantive, it eventually starts spurting from your lips, ultimately forcing you to pull free of his tool and get doused with the remnant flood of the creature's virile seed[end if].";
+		say " [if boundstate is true]though he relents just enough to not overwhelm you, [end if]making you rapidly swallow down his sexual fluids just to keep up. This ritual [if hp of player < 1]forcibly[otherwise]quickly[end if] [if cocks of player > 0]drives your dick[smn] erect, throbbing in the open air[otherwise if cunts of player > 0]makes you cunt[sfn] ache with an overwhelming need[otherwise]makes you aroused, though you have no way of sating it[end if], a matter you're too preoccupied right now to properly attend to, as the beast thrusts instinctively against your attending hole.";
+		say "    With a low, loud groan, the reptile [if boundstate is true]suddenly pins you down, forcing almost the entire length down your throat. flooding[otherwise]floods[end if] your gullet with its thick, creamy fluid. [if boundstate is true and sierrapure is true]The creature is happy to feed its little companion, generating a fair amount more than what is normal for it, probably also using this time to train you, as your torso bloats to abide the overwhelming flood[otherwise if boundstate is true]The creature is dead set on forcing you to swallow all of it down, and it's quickly clear that it seems to be generating more than usual, your stomach quickly bloating to abide this overwhelming flood[otherwise if sierrapure is true]The creature is happy to feed its little companion, flooding your belly with its virile seed[otherwise]The flood is so substantive, it eventually starts spurting from your lips, ultimately forcing you to pull free of his tool and get doused with the remnant flood of the creature's virile seed[end if].";
 		if sierramem is 2:
 			say "     [if hp of player < 1]Thankfully[otherwise if sierrapure is true]Much to your approval[otherwise]Interestingly enough[end if], the taste is not all that bad, this lewd nectar mildly sweet and clearly filling";
-			If vorestate is true:
+			If boundstate is true:
 				say ". You imagine this is probably where the essence the beast has been draining has been going, [if sierrapure is true]eager to sustain its twisted offspring[otherwise]odd that it wants to feed it back to you[end if]";
 			otherwise:
 				say ". You imagine the beast seed is particularly sustaining, [if sierrapure is true]eager to aid one of its smaller kin[otherwise]strange though it may be[end if]";
 			now sierramem is 3;
 		otherwise:
 			say "     [if hp of player < 1 and sierrapure is false]Groaning weakly[otherwise]Moaning[end if], you're full with the beast's sweet, tainted nectar";
-			If vorestate is true:
+			If boundstate is true:
 				say ", who's [if sierrapure is true]eager to sustain its twisted offspring[otherwise]eager to feed your essence back to you[end if]";
 			otherwise:
 				say ", who's [if sierrapure is true]eager to aid one of its smaller kin[otherwise]strangely eager to sustain you[end if]";
 		increase lustatt by 45 + (lustadjust * 10);
-		if (libido of player > 49 and vorestate is false) or lustatt > 99:
+		if (libido of player > 49 and boundstate is false) or lustatt > 99:
 			say ". Too overtaken by your own need, you almost immediately resort to [if cocks of player > 0]jacking yourself off[otherwise if cunts of player > 0]fingering yourself[otherwise]fondling yourself[end if] madly right then and their. It doesn't take much work to set you off, [if cocks of player > 1]dicks spurting their [cum load size of player] load into the open air and making a bigger mess of things[otherwise if cocks of player is 1]dick spurting its [cum load size of player] load into the open air and making a bigger mess of things[otherwise if cunts of player > 0]cunt[sfn] throbbing firmly against your touch[otherwise]barely able to find some reprieve out of your genderless form[end if]. The beast doesn't seem to regard this all that much, letting you perform this ritual.";
 			if struggleatt > 0, decrease struggleatt by 1;
 			decrease libido of player by (libido of player / 10);
 			if libido of player < 0, now libido of player is 0;
 			now lustatt is libido of player;
-			if vorestate is true, decrease humanity of player by 15 + (psycheadjust * 5);
+			if boundstate is true, decrease humanity of player by 15 + (psycheadjust * 5);
 		otherwise:
 			say ". Aching with need after the whole ordeal, it takes you a moment to calm down, the beast patiently giving you a moment to catch your breath.";
-	if vorestate is false:
-		say "     After that, it pulls away, slowly stepping back and letting you depart. It just… Stands there, and only watches you passively as you get up and step away, strangely indifferent to your departure as you gather your things and leave.";
+	if boundstate is false:
+		say "     After that, it pulls away, slowly stepping back and letting you depart. It just... Stands there, and only watches you passively as you get up and step away, strangely indifferent to your departure as you gather your things and leave.";
 	otherwise:
 		say "     Pulling back away from you, it's clearly set on consuming you once more, [if hp of player < 1]you try to fight back, but you're still too weak and exhausted to really do anything, and as such the creature entirely ignores you protests[otherwise if sierrapure is true]your infection compelling a jovial regard at the thought being brought back into your room again[otherwise]that familiar, gaping abyss exposed to you[end if] before his maw gently wraps around your [bodytype of player] form. Shoving you gradually back down the slick hole, each successive, ponderous gulp sucks you into these unyielding confines until you're forced to reconvene with your [if humanity of player < 51]new home[otherwise]twisted prison[end if].";
 		decrease hunger of player by 3; [Effect is doubled for abducted players]
@@ -247,7 +247,7 @@ to sierrasex:
 	if thirst of player < 0, now thirst of player is 0;
 
 to say beathesierra:
-	say "     After struggling with the beast for a while, it disengages from you entirely. Looking it over, it doesn’t seem you’ve put a dent into it, but it does at least appear to have conceded to your will. If you step closer to it, it’s demeanour is mildly sheepish, inferring a slight submissive gesture from the otherwise indifferent-appearing creature. Matter resolved, you choose to depart."; [Victory sex NYI]
+	say "     After struggling with the beast for a while, it disengages from you entirely. Looking it over, it doesn't seem you've put a dent into it, but it does at least appear to have conceded to your will. If you step closer to it, it's demeanour is mildly sheepish, inferring a slight submissive gesture from the otherwise indifferent-appearing creature. Matter resolved, you choose to depart."; [Victory sex NYI]
 
 
 to say sierradesc:
@@ -388,13 +388,13 @@ when play ends:
 		if humanity of player is less than 10:
 			if voreloss is true:
 				say "     Succumbing from inside the reptile, you eventually grow obsessively fond of these twisted confines. Though you never grow to full size, you nonetheless remain ever tended to by your parental kin, leaving your new home only to be fed ";
-				if (cunts of player > 0 or “Mpreg” is listed in feats of player) and “Infertile” is not listed in feats of player:
+				if (cunts of player > 0 or "Mpreg" is listed in feats of player) and "Infertile" is not listed in feats of player:
 					say "and give birth to the beast's offspring";
 				otherwise if cocks of player > 0:
 					say "and sire the beast's offspring";
 				say ".";
 				say "     Over time, the creature's pack grows in size, leaving you with others to deal with";
-				if “Submissive” is listed in feats of player:
+				if "Submissive" is listed in feats of player:
 					say ". So innately inclined to this role, you eventually find yourself being tossed from beast to beast, like some manner of toy. You find yourself particularly useful as a tool for training the newer and less experienced of your kin";
 				otherwise:
 					say ". You prove to be a little bit of a nuisance, as you're rather ill-inclined to share your adoptive parent's fleshy abode with new prospects. Your caretaker doesn't seem to mind all that much, even if it's proves a bit inconvenient at times";
@@ -402,11 +402,11 @@ when play ends:
 			otherwise:
 				say "     Overwhelmed by your infection you eventually lose all self control, made to wander the land a ponderous, twisted beast. Your strain eventually progresses until you fully assume the form of your kin, now a mere animal in the eyes of those unwise enough to enter your reach.";
 				say "     Encountering one such individual, no doubt searching for survivors, you instinctively subdue them before they are drawn within your slick confines, your new child soon made to be consort. It takes only a few of its beloved occupancy, intermittently broken up by your wanton rituals of feeding, that your new companion succumbs as you had, eventually offering itself";
-				if cocks of player > 0 and ((cunts of player > 0 or “Mpreg” is listed in feats of player) and “Infertile” is not listed in feats of player) and sierramale is false:
+				if cocks of player > 0 and ((cunts of player > 0 or "Mpreg" is listed in feats of player) and "Infertile" is not listed in feats of player) and sierramale is false:
 					say "to sire your children and you to sire its";
 				otherwise if cocks of player > 0 and sierramale is false:
 					say "for you to sire its children";
-				otherwise if (cunts of player > 0 or “Mpreg” is listed in feats of player) and “Infertile” is not listed in feats of player:
+				otherwise if (cunts of player > 0 or "Mpreg" is listed in feats of player) and "Infertile" is not listed in feats of player:
 					say "to sire your children";
 				otherwise:
 					say "to satisfy you on a whim and help you find more to be brought into the fold";

--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -6001,7 +6001,8 @@ Include Cowboy Cuntboy by Wahn.
 Include Thought Eater by Wahn.
 Include Batcubus for FS by Blaydrex.
 Include Sierrasaur by Blue Bishop.
-[Include Pewter Consort By Blue Bishop.]
+Include Pewter Consort By Blue Bishop.
+
 
 [NPCs]
 Include Velos by Blue Bishop.


### PR DESCRIPTION
Implements the first phase of content for a new monster, the Pewter Consort. Available in the capitol region, this male encounter contains the second Bound State in the game.
