### PR TITLE
Header name change for extensions.

### DIFF
--- a/Auto Translator/Green Hydra.i7x
+++ b/Auto Translator/Green Hydra.i7x
@@ -1,4 +1,4 @@
-Green Hydra for FS by Auto Translator begins here. 
+Green Hydra by Auto Translator begins here. 
 [This monster was translated from the multiplayer game automatically by Nuku Valente, but may, most likely, have been written by someone else.]
 
 "Adds Green Hydra to Flexible Survival."

--- a/Nuku Valente/Mall Rat for FS.i7x
+++ b/Nuku Valente/Mall Rat for FS.i7x
@@ -1,3 +1,4 @@
+Mall Rat For FS by Nuku Valente begins here.
 [This monster was translated from the multiplayer game automatically by Nuku Valente, but may, most likely, have been written by someone else.]
 
 "Adds Mall Rat to Flexible Survival."

--- a/Nuku Valente/Story Skipper backup.i7x
+++ b/Nuku Valente/Story Skipper backup.i7x
@@ -1,4 +1,4 @@
-Story Skipper by Nuku Valente begins here.
+Story Skipper backup by Nuku Valente begins here.
 
 Trixie is a person. Trixie is in Grey Abbey Library.
 


### PR DESCRIPTION
Several errors were reported on extensions indicating that the ‘begins here’ line was incorrect or missing.
