### PR TITLE
More Punctuation

### DIFF
--- a/Wahn/Chris.i7x
+++ b/Wahn/Chris.i7x
@@ -11,7 +11,7 @@ Version 1 of Chris by Wahn begins here.
 [   2: orc warrior                                 ]
 				
 Chris is a man.  The hp of Chris is normally 0. 
-The description of Chris is "[ChrisDesc]";
+The description of Chris is "[ChrisDesc]".
 The conversation of Chris is { "Mew!" }.
 
 instead of sniffing Chris:

--- a/Wahn/Orc Lair.i7x
+++ b/Wahn/Orc Lair.i7x
@@ -28,7 +28,7 @@ Koghhstatus is a number that varies.
 BoghrimMet is a number that varies.
 
 Orcish Slave Raid is a situation.
-The sarea of Orcish Slave Raid is "Warehouse";
+The sarea of Orcish Slave Raid is "Warehouse".
 when play begins:
 	add Orcish Slave Raid to badspots of guy;       [male orcs]
 
@@ -286,19 +286,19 @@ to say LoseToOrcSlavers:
 Section 2 - Orc Lair
 			
 Orc Lair Side Entrance is a room. It is a fasttravel. It is private.
-The description of Orc Lair Side Entrance is "     You're standing outside a side door leading into the Capitol District police station. Maybe it'd be a good idea not to stay here too long, with this being the main orc lair in the city. Sooner or later, one of them is bound to come out or return here...";
+The description of Orc Lair Side Entrance is "     You're standing outside a side door leading into the Capitol District police station. Maybe it'd be a good idea not to stay here too long, with this being the main orc lair in the city. Sooner or later, one of them is bound to come out or return here...".
 
 West of Orc Lair Side Entrance is Dark Hallway 2.
-The description of Dark Hallway 2 is "     You're in a long windowless hallway continuing to the west and ending at the side door of the building in the east. An unmarked door leads to the north. It's pretty dark in here with no windows or electricity for the lights on the ceiling.";
+The description of Dark Hallway 2 is "     You're in a long windowless hallway continuing to the west and ending at the side door of the building in the east. An unmarked door leads to the north. It's pretty dark in here with no windows or electricity for the lights on the ceiling.".
 
 North of Dark Hallway 2 is Observation Room.
-The description of Observation Room is "     This is a relatively small room with recording equipment and a one-way-mirror window in the west wall, allowing a view into the interrogation room to the west. Not much to see currently, though - it's pretty dark in there. Though from what you can make out of its contents... and the splash of what's clearly dried cum on the glass, you'd bet that room has seen quite a bit of use recently. Interestingly, the sound system is hooked up to a car battery standing on the single table in here - so you bet one could also hear everything going on next door clearly. Maybe it'd be worth your while to [bold type]wait[roman type] here and observe what might happen.";
+The description of Observation Room is "     This is a relatively small room with recording equipment and a one-way-mirror window in the west wall, allowing a view into the interrogation room to the west. Not much to see currently, though - it's pretty dark in there. Though from what you can make out of its contents... and the splash of what's clearly dried cum on the glass, you'd bet that room has seen quite a bit of use recently. Interestingly, the sound system is hooked up to a car battery standing on the single table in here - so you bet one could also hear everything going on next door clearly. Maybe it'd be worth your while to [bold type]wait[roman type] here and observe what might happen.".
 
 before going North from Dark Hallway 2:
 	say "     The door of the observation room is a bit warped or something, requiring you to wiggle and lift the doorknob a bit as you open it. That fact, together with the relatively small size of the room might actually make it a rare safe spot in the orc lair. If you do want to get some rest somewhere in here, this would be the place to do it...";
 
-West of Dark Hallway 2 is Dark Hallway 1;
-The description of Dark Hallway 1 is "     You're in a long windowless hallway continuing to the east and ending at the entrance of a large room in the west. From the sounds of many orcs talking, drinking and fucking that echo from in there, you're pretty sure you shouldn't go that way right now. Thankfully, with no electricity to run the lights, it's pretty dark in the hallway, so you're relatively safe in its shadowy length. A locked door bearing a plaque with 'Interrogation' on it leads to the north, while another with the sign 'Cells' lies to the south.";
+West of Dark Hallway 2 is Dark Hallway 1.
+The description of Dark Hallway 1 is "     You're in a long windowless hallway continuing to the east and ending at the entrance of a large room in the west. From the sounds of many orcs talking, drinking and fucking that echo from in there, you're pretty sure you shouldn't go that way right now. Thankfully, with no electricity to run the lights, it's pretty dark in the hallway, so you're relatively safe in its shadowy length. A locked door bearing a plaque with 'Interrogation' on it leads to the north, while another with the sign 'Cells' lies to the south.".
 
 after going west from Dark Hallway 2 while a random chance of 1 in 2 succeeds:
 	say "    [OrcLairMainChamberWatching]";
@@ -307,8 +307,8 @@ after going north from Breeder Lockup A while a random chance of 1 in 2 succeeds
 	say "    [OrcLairMainChamberWatching]";
 	
 
-West of Dark Hallway 1 is Main Hall;
-The description of Main Hall is "     This is the main hall of the orc lair, where the big brutes come to chug beer, hang out, fuck and fight. All the desks in what previously was the main working area of this police station have been pushed together to form a long table in the center of the room, which is laden with food and drink - whole kegs of beer and all kinds of other stuff. Mattresses and sofas brought in from somewhere else are strewn about the room - with some of them currently in use by the twenty-odd orcs present.";
+West of Dark Hallway 1 is Main Hall.
+The description of Main Hall is "     This is the main hall of the orc lair, where the big brutes come to chug beer, hang out, fuck and fight. All the desks in what previously was the main working area of this police station have been pushed together to form a long table in the center of the room, which is laden with food and drink - whole kegs of beer and all kinds of other stuff. Mattresses and sofas brought in from somewhere else are strewn about the room - with some of them currently in use by the twenty-odd orcs present.".
 
 instead of going West from Dark Hallway 1:
 	if bodyname of player is "Orc Warrior" and player is pure:
@@ -326,14 +326,14 @@ instead of going West from Dark Hallway 2 while bodyname of player is "Orc Warri
 instead of going North from Breeder Lockup A while bodyname of player is "Orc Warrior" and player is pure and BoghrimMet is 0:
 	say "[BoghrimSlaveDeal]";
 	
-West of Main Hall is Bright Hallway 1;
-The description of Bright Hallway 1 is "     You're in a long hallway with a big, wire-reinforced window at its end in the west. That and the row of still-working fluorescent lights on the ceiling illuminate it brightly. Two closed (and locked) doors flank the hallway to the north and south, while it extends further to the west and ends in the east at the main hall of the police station turned orc lair.";
+West of Main Hall is Bright Hallway 1.
+The description of Bright Hallway 1 is "     You're in a long hallway with a big, wire-reinforced window at its end in the west. That and the row of still-working fluorescent lights on the ceiling illuminate it brightly. Two closed (and locked) doors flank the hallway to the north and south, while it extends further to the west and ends in the east at the main hall of the police station turned orc lair.".
 
-West of Bright Hallway 1 is Bright Hallway 2;
-The description of Bright Hallway 2 is "     You're in a long hallway that ends at a big, wire-reinforced window in the west wall. That and the row of still-working fluorescent lights on the ceiling illuminate it brightly. Two doors flank this section of the hallway to the north and south, with the northern one closed and locked, while the southern one hangs a bit crookedly and has a splintered ruin where its lock and handle once were.";
+West of Bright Hallway 1 is Bright Hallway 2.
+The description of Bright Hallway 2 is "     You're in a long hallway that ends at a big, wire-reinforced window in the west wall. That and the row of still-working fluorescent lights on the ceiling illuminate it brightly. Two doors flank this section of the hallway to the north and south, with the northern one closed and locked, while the southern one hangs a bit crookedly and has a splintered ruin where its lock and handle once were.".
 
-South of Bright Hallway 2 is Police Station Lockerroom;
-The description of Police Station Lockerroom is "[PLRDesc]";
+South of Bright Hallway 2 is Police Station Lockerroom.
+The description of Police Station Lockerroom is "[PLRDesc]".
 PLRLooted is a number that varies.
 
 to say PLRDesc:
@@ -344,10 +344,10 @@ to say PLRDesc:
 
 LockerLooting is an action applying to nothing.
 
-understand "loot locker" as LockerLooting;
-understand "loot lockers" as LockerLooting;
-understand "loot the locker" as LockerLooting;
-understand "loot the lockers" as LockerLooting;
+understand "loot locker" as LockerLooting.
+understand "loot lockers" as LockerLooting.
+understand "loot the locker" as LockerLooting.
+understand "loot the lockers" as LockerLooting.
 
 Carry out LockerLooting:
 	LootLocker;
@@ -411,13 +411,13 @@ to say OrcLairMainChamberWatching:
 			say "     As it splashes down, you realize that the creature consists of nothing but cum and has a feminine figure - though not for long, as the cum girl immediately starts to meld with the orc seed all around herself. She quivers and shifts, her face showing an expression of surprise as she looks down and sees green veins working their way through her body. When the rapid change of the cum creature finishes, it no longer looks female, but has the form of a burly and muscular, if a bit slimy-looking, orc. The newly transformed cum-orc gives a loud bellow and wades forward with sloshing movements to sink its mouth on the nearest orc's cock, hungry for more.";
 			say "     Finally shaking off the strange fascination that made you watch the things going on in there, you duck back into the dark shadows of the hallway. Getting caught up in between all the orcs in the main chamber of this police station turned orc lair is really something you should avoid - especially as they just might throw you in with their new pet at the moment.";			
 
-South of Dark Hallway 1 is Breeder Lockup A;
-The description of Breeder Lockup A is "     You're in a room holding two large cells to the east and west - most likely originally the 'drunk tank' and another group holding cell. Now the orcs use them to lock up their newly caught slaves. A door to the north allows you to leave this place again. A bent nail to hold a key is driven into the south wall, well out of reach of anyone inside the cells.";
+South of Dark Hallway 1 is Breeder Lockup A.
+The description of Breeder Lockup A is "     You're in a room holding two large cells to the east and west - most likely originally the 'drunk tank' and another group holding cell. Now the orcs use them to lock up their newly caught slaves. A door to the north allows you to leave this place again. A bent nail to hold a key is driven into the south wall, well out of reach of anyone inside the cells.".
 
 Cell Door 1 is a door.
-Cell Door 1 is west of Breeder Lockup A;
+Cell Door 1 is west of Breeder Lockup A.
 Cell Door 1 is lockable and locked.
-The description of Cell Door 1 is "    A metal cell door, consisting of a sturdy frame and several cell bars, plus three crossbars. Its lock has a mechanism that locks itself when the door swings shut, as well as a spring at the top preventing it from standing open without someone holding on to it. [if CellDoorStatus is 1 or CellDoorStatus is 3]Though looking closer, you realize the lock has been busted and won't engage at all now - which makes this a pretty easy to escape cell[end if]"; 
+The description of Cell Door 1 is "    A metal cell door, consisting of a sturdy frame and several cell bars, plus three crossbars. Its lock has a mechanism that locks itself when the door swings shut, as well as a spring at the top preventing it from standing open without someone holding on to it. [if CellDoorStatus is 1 or CellDoorStatus is 3]Though looking closer, you realize the lock has been busted and won't engage at all now - which makes this a pretty easy to escape cell[end if]".
 Cell Key unlocks Cell Door 2.
 
 Slave Cell 1 is a room. 
@@ -426,9 +426,9 @@ Slave Cell 1 is sleepsafe.
 The description of Slave Cell 1 is "     This large cell holds a bed in the back, as well as a backless leather bench that's clearly meant to have sex on. It's seen quite a bit of use, judging from the cum-stains all over it and on the floor around. Shreds of fabric and quite a few ripped pieces of clothing lie strewn about on the floor. The only exit from this cell is a door in the east. [if Cell Key is owned]Good that you have a key, otherwise you might get stuck in here. [otherwise if CellDoorStatus is 1 or CellDoorStatus is 3]Good that the lock is busted, otherwise you'd be stuck in here.[otherwise]You're stuck in here - unless you find a way to [bold type]escape the cell[roman type].[end if]".
 
 Cell Door 2 is a door.
-Cell Door 2 is east of Breeder Lockup A;
+Cell Door 2 is east of Breeder Lockup A.
 Cell Door 2 is lockable and locked.
-The description of Cell Door 2 is "    A metal cell door, consisting of a sturdy frame and several cell bars, plus three crossbars. Its lock has a mechanism that locks itself when the door swings shut, as well as a spring at the top preventing it from standing open without someone holding on to it. [if CellDoorStatus is 2 or CellDoorStatus is 3]Though looking closer, you realize the lock has been busted and won't engage at all now - which makes this a pretty easy to escape cell[end if]"; 
+The description of Cell Door 2 is "    A metal cell door, consisting of a sturdy frame and several cell bars, plus three crossbars. Its lock has a mechanism that locks itself when the door swings shut, as well as a spring at the top preventing it from standing open without someone holding on to it. [if CellDoorStatus is 2 or CellDoorStatus is 3]Though looking closer, you realize the lock has been busted and won't engage at all now - which makes this a pretty easy to escape cell[end if]".
 Cell Key unlocks Cell Door 2.
 
 Slave Cell 2 is a room. 
@@ -593,13 +593,13 @@ CellDoorStatus is a number that varies;
 
 CellEscape is an action applying to nothing.
 
-understand "escape this cell" as CellEscape;
-understand "escape the cell" as CellEscape;
-understand "escape cell" as CellEscape;
-understand "escape this slave cell" as CellEscape;
-understand "escape the slave cell" as CellEscape;
-understand "escape slave cell" as CellEscape;
-understand "break out" as CellEscape;
+understand "escape this cell" as CellEscape.
+understand "escape the cell" as CellEscape.
+understand "escape cell" as CellEscape.
+understand "escape this slave cell" as CellEscape.
+understand "escape the slave cell" as CellEscape.
+understand "escape slave cell" as CellEscape.
+understand "break out" as CellEscape.
 
 check CellEscape:
 	if player is not in Slave Cell 1 and player is not in Slave Cell 2, say "You're not in a cell at the moment." instead;
@@ -1276,7 +1276,7 @@ to say BoghrimSlaveDeal:
 Section 3 - NPCs
 
 Mul is a man. 
-The description of Mul is "[MulDesc]";
+The description of Mul is "[MulDesc]".
 The conversation of Mul is { "Mew!" }.
 
 to say MulDesc:
@@ -1292,7 +1292,7 @@ instead of fucking Mul:
 	say "     He's pretty worn out, let him sleep for now.";
 	
 Boghrim is a man.  Boghrim is in Main Hall.
-The description of Boghrim is "[BoghrimDesc]";
+The description of Boghrim is "[BoghrimDesc]".
 The conversation of Boghrim is { "Mew!" }.
 
 to say BoghrimDesc:
@@ -1414,7 +1414,7 @@ instead of fucking Boghrim:
 
 
 Orc Mob is a man.
-The description of Orc Mob is "About twenty orc warriors hang around in here and are busy drinking, boasting about themselves, even fucking an orc breeder or two right in the middle of the room. Their brutish impulses really come to the forefront in a group, and you can see games of strength like arm-wrestling and fights where they barely hold back going on. The big room is filled with a constant background noise of deep-voiced cajoling and conversation, in combination with grunts and moans.";
+The description of Orc Mob is "About twenty orc warriors hang around in here and are busy drinking, boasting about themselves, even fucking an orc breeder or two right in the middle of the room. Their brutish impulses really come to the forefront in a group, and you can see games of strength like arm-wrestling and fights where they barely hold back going on. The big room is filled with a constant background noise of deep-voiced cajoling and conversation, in combination with grunts and moans.".
 The conversation of Orc Mob is { "Yap!" }.
 Orc Mob is in Main Hall.
 
@@ -1436,7 +1436,7 @@ instead of fucking the gang members:
 		say "     Walking up to drunken, horny orcs and asking if you can fuck them doesn't sound like a good strategy. Orcs warriors are built to fuck, not get taken by others, so you'd likely only earn some punches to the face...";
 
 Jason is a man.  Jason is in Main Hall.
-The description of Jason is "[JasonDesc]";
+The description of Jason is "[JasonDesc]".
 The conversation of Jason is { "Having his nose pressed against Boghrim's crotch as he licks and fondles his master makes it just a bit difficult to talk to Jason. Combined with the fact that he's also a bit buzzed from swallowing the big orc's precum, you don't think there's much use talking to him right now..." }.
 
 to say JasonDesc:

--- a/Wahn/Val.i7x
+++ b/Wahn/Val.i7x
@@ -18,7 +18,7 @@ Version 1 of Val by Wahn begins here.
 [  4: kid born and taken while the player was out              ]
 		
 Val is a man.  The hp of Val is normally 0. 
-The description of Val is "[ValDesc]";
+The description of Val is "[ValDesc]".
 The conversation of Val is { "Mew!" }.
 ValPregCounter is a number that varies.
 ValPregnancy is a number that varies.


### PR DESCRIPTION
Updated punctuation based on rules for Inform 7 (build 6L02).
The text is followed by a semicolon ';', which only makes sense to me
inside a rule or phrase (where there's a heading, then a colon, then a
list of instructions divided by semicolons). Perhaps you want a full
stop '.' instead?
