### PR TITLE
Header Case Correction

### DIFF
--- a/AGentlemanCalledB/Francois Infections.i7x
+++ b/AGentlemanCalledB/Francois Infections.i7x
@@ -1,4 +1,4 @@
-Version 1 of Francois Infections by AGentlemancalledB begins here.
+Version 1 of Francois Infections by AGentlemanCalledB begins here.
 [Version 1 - Adds Cheesecake and Gingerbread infections for use with Francois.]
 
 Section 1 - Monster Responses

--- a/Kaleem mcintyre/Pursuit of Science.i7x
+++ b/Kaleem mcintyre/Pursuit of Science.i7x
@@ -1,4 +1,4 @@
-Version 3 of Pursuit of Science by Kaleem Mcintyre begins here.
+Version 3 of Pursuit of Science by Kaleem mcintyre begins here.
 [ Version 3 - Corrections made.  Quests functional (?) ]
 
 Section 1 - Questing Chain

--- a/Sarokcat/Brian.i7x
+++ b/Sarokcat/Brian.i7x
@@ -1,4 +1,4 @@
-Version 2 of Brian by SarokCat begins here.
+Version 2 of Brian by Sarokcat begins here.
 [ Version 2 - Sex w/Brian - finally - added by Stripes]
 
 "Adds a single-mindedly determined rhino named Brian to Flexible Survival."

--- a/Sarokcat/Diego.i7x
+++ b/Sarokcat/Diego.i7x
@@ -1,4 +1,4 @@
-Version 1 of Diego by SarokCat begins here.
+Version 1 of Diego by Sarokcat begins here.
 [ Version 1 - Breakup of Zoo People file ]
 
 "Adds a coyote named Diego to Flexible Survival."

--- a/Sarokcat/Timothy.i7x
+++ b/Sarokcat/Timothy.i7x
@@ -1,4 +1,4 @@
-Version 1 of Timothy by SarokCat begins here.
+Version 1 of Timothy by Sarokcat begins here.
 [ Version 1 - Breakup of Zoo People file ]
 
 "Adds a herm gryphon breeder with room for company in her nest to Flexible Survival."


### PR DESCRIPTION
Corrected the case of the header in several files. This was causing the
submenus to show multiple times with different cases with all of the
files of that folder listed for each submenu.

i.e.
AGentlemanCalledB/Fire Sprite
AGentlemanCalledB/Francois
AGentlemanCalledB/Karen
AGentlemancalledB/Fire Sprite
AGentlemancalledB/Francois
AGentlemancalledB/Karen
