### PR TITLE
fix for double scenes in defeat by female wyverns

### DIFF
--- a/Damaged/Wyvern For FS.i7x
+++ b/Damaged/Wyvern For FS.i7x
@@ -165,7 +165,7 @@ to say WYVVIC:
 				otherwise:
 					say "'lay' the egg after [if scalevalue of player is 3]a substantial amount of[otherwise]some[end if]";
 			say "effort, [if scalevalue of player is 3]brutally[otherwise]very[end if] sore after the whole endeavour. Looking at them now, they appear to be stirring, no doubt roused by this particular ritual, and you set yourself to hobble off before you must contend with them as well, no doubt quite aroused by the whole venture[if hp of player < 1 and player is not submissive], much in spite your better judgment[end if].";
-		if vorelevel is 3 and (a random chance of 1 in 4 succeeds or ("Kinky" is listed in feats of player and a random chance of 1 in 3 succeeds)) and boundstate is false:
+		otherwise if vorelevel is 3 and (a random chance of 1 in 4 succeeds or ("Kinky" is listed in feats of player and a random chance of 1 in 3 succeeds)) and boundstate is false:
 			say "[wyvorescene]";
 		otherwise if scalevalue of player < 4 and ublevel is not 1 and (A random chance of 2 in 3 succeeds or ublevel is 3) and boundstate is false:
 			say ". The monster circles around you for a moment, intent on asserting her dominance by screeching at you as she eyes you over.";


### PR DESCRIPTION
This patch should prevent egg transferal scenes with female wyverns from being followed by another defeat scene in the same combat loss.