### PR TITLE
Unbirth Pregnancy Fix

### DIFF
--- a/Core Mechanics/Alt Vore.i7x
+++ b/Core Mechanics/Alt Vore.i7x
@@ -302,6 +302,7 @@ to ubbyplayer:
 	decrease humanity of player by 3;
 	now gestation of child is a random number between 8 and 16;
 	now ubpreg is name entry;
+	now pregtype is 1;
 	if "Safe Appetite" is not listed in feats of player:
 		now researchbypass is 1;
 		infect;


### PR DESCRIPTION
Resolves an incongruity with the player-inflicted unbirth system and the updated pregnancy system that would stop child gestation due to a lack of a properly assigned pregnancy type.

I feel a long comment will make up for an otherwise simplistic merge.