### PR TITLE
Tome Counter Reset Fix

### DIFF
--- a/Dys/Additional Tome Scenes.i7x
+++ b/Dys/Additional Tome Scenes.i7x
@@ -242,7 +242,7 @@ an everyturn rule:
 				say "     You blink, suddenly aware that your hand is reaching into your bag, seemingly on its own accord. Wondering what could possibly be going on, you grab the first thing you touch and pull it out. It just so happens to be the [bold type]ancient tome[roman type]! You glance over its leather cover, running your fingers across its surface for a second before you flip the cover open, going to a random page. Much to your amazement, you can actually read the words there! [bold type]Perhaps you could give it a read, now that you can actually do so?[roman type]";
 				now TomeTimer is turns;
 				now TomeInfluence is 3;
-		else if TomeInfluence is 3: [Tempted fully]
+		else if TomeInfluence is 3 and a random chance of 1 in 3 succeeds: [Tempted fully]
 			if TomeTimer - turns >= 8:
 				say "     You can't help but feel drawn to the book inside your bag. The [bold type]ancient tome[roman type] really seems like it wants you to [if TomeInteractions is 0]read it, now that you finally can[else]read it once more[end if].";
 				now TomeTimer is turns;


### PR DESCRIPTION
Once `TomeInfluence` hits 3, then the `TentaclesFirstEncounter` is never seen.  As long as the Tome is in the inventory, and the player only has a cock, every 8 turns, the `TomeTimer` will *always* be reset before the check for the `TentaclesFirstEncounter` happens.  There are a few options to resolve this:

1. Increase the turn gap between which the temptations happen from 8 to another number greater than 8.
2. Decrease the turn gap for `TentaclesFirstEncounter` from 8 to another number less than 8.
3. Remove the tome from the inventory.
4. Make the temptation randomized, e.g. add a 1 in 3 chance of happening.

I went with number 4 for this PR because there is logic for the `TentaclesFirstEncounter` scene that forces it after 12 turns, making 1 pointless unless the turn gap is greater than 12, making 2 pointless, leaving 3 or 4 as options. 3 is pointless because it is obvious that the player *should* be able to interact with the tome throughout this whole thing, leaving 4 as the only reasonable solution. 