### PR TITLE
Updates for Tome + Vent

### DIFF
--- a/Dys/Additional Tome Scenes.i7x
+++ b/Dys/Additional Tome Scenes.i7x
@@ -109,7 +109,7 @@ to say TomeExpansionUse:
 				say "     [link](N)[as]n[end link] - It's probably best not to.";
 				if player consents:
 					say "     You open the tome to a random page, deciding that no real harm can come from just quick glance at it. Your eyes skim over page after page of text and drawings depicting all sorts of monsters and demons, taking all the information in eagerly. For some reason you can't quite comprehend, the contents of the book have really piqued your interest. Nearly two hours later, you find that you've read more than half of the large books contents, and you suddenly blink, realizing how much time you've spent doing this. Shutting the book, you heave a sigh as you place it in your pack before moving on. There's some part of you that eagerly awaits further reading.";
-					noe TomeTimer is turns;
+					now TomeTimer is turns;
 					now TomeInteractions is 1;
 				else:
 					say "     You shake your head, deciding that there's not really any benefit to reading the contents of the book, before you place it back in your pack and move along.";

--- a/Dys/Vent Fox.i7x
+++ b/Dys/Vent Fox.i7x
@@ -1189,7 +1189,18 @@ to say VentAnalWS:
 		else if VentFluidAmount is 3: [Extreme levels of urine.]
 			say "     Vent takes a leak in your ass, making you look like you're ready to give birth.";
 	else: [No WS.]
-		say "     With his knot still engorged, your latex fox friend lays down on top of you, snuggling up against you as you both come down from your high. While you wait for the bulb of rubber to shrink, he goes about cleaning your spilling cum, darting his extendable tongue out of his mouth to lap up the mess. After he finishes with that, he simply opts to curl around you, waiting for his body to calm down. You can't help the feeling of safety that comes over you as you relax in his embrace.";
+		if VentDomSize is 3 and scalevalue of player > 1: [Vent is average sized and player is not tiny]
+			say "     With his knot still engorged, your latex fox friend lays down on top of you, snuggling up against you as you both come down from your respective highs. While you wait for the bulb of rubber to shrink, he goes about cleaning your spilled cum, darting his extendable tongue out of his mouth to lap up the mess. After he finishes with that, he simply opts to curl around you, waiting for his body to calm down. You can't help the feeling of safety that comes over you as you relax in his embrace.";
+		else if VentDomSize is 3 and scalevalue of player is 1: [Vent is average sized and player is tiny]
+			say "     With your tiny form still stuck on his knot and your belly swollen with his seed, Vent places a relatively large paw on your chest, holding you gently as the two of you come down from your bliss. He gives you a few gentle licks with his rubbery tongue as you both wait for his knot to come down. You can't help but relax from the feeling of comfort you get from being with your latex friend.";
+		else if VentDomSize is 4 and scalevalue of player > 2: [Vent is large and player is not small]
+			say "     Vent lays atop your form, sighing as he comes down from his climax. His tail sways gently behind him.";
+		else if VentDomSize is 4 and scalevalue of player <= 2: [Vent is large and player is small]
+			say "     With your tiny body still stuck on his knot, Vent holds you close until his knot deflates.";
+		else if VentDomSize is 5 and scalevalue of player > 3: [Vent is huge and player is not average]
+			say "     Vent lays atop your form, sighing as he comes down from his climax. His tail sways gently behind him.";
+		else if VentDomSize is 5 and scalevalue of player <= 3: [Vent is huge and player is average]
+			say "     With your tiny body still stuck on his knot, Vent holds you close until his knot deflates.";
 
 to say VentPostSexWS:
 	if (VentWSAmount is 2 and a random chance of 1 in 3 succeeds) or (VentWSAmount is 3):


### PR DESCRIPTION
# Changelog

- Fixes a typo in the code for `Ancient Tome Expansion.i7x` that didn't properly set the cooldown after reading the tome the first time.
- Fixes some grammatical errors in `Vent Fox.i7x`.
- Adds some extra scenes for post-sex-no-ws in `Vent Fox.i7x` if the player is tiny, relative to `VentDomSize`.
