### PR TITLE
adding text to ctags regex to get ghis/gdragon/etc

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -1,6 +1,7 @@
 --langdef=Inform
 --langmap=Inform:.i7x.ni
 --regex-Inform=/^\s*(.+?) ?is a (number|truth state) that/\1/f,func/
+--regex-Inform=/^\s*(.+?) ?is text that/\1/f,func/
 --regex-Inform=/^\s*(.+?) ?is a situation/\1/f,func/
 --regex-Inform=/^\s*to say ?(.+?) ?:/\1/f,func/
 --regex-Inform=/^\s*carry out ?(.+?):]/\1/f,func/


### PR DESCRIPTION
Doran has a bunch of [ghis] and [gher] tags that weren't captured before. they are now.