### PR TITLE
Missing Fur Brush fix

### DIFF
--- a/Core Mechanics/Basic Locations.i7x
+++ b/Core Mechanics/Basic Locations.i7x
@@ -97,10 +97,12 @@ George's Animal Emporium is southwest of Looted Shops.
 The description of George's Animal Emporium is "[PetShopDesc]".
 
 to say PetShopDesc:
-	say "     You're in a mid-sized pet store that has been recently looted. Judging from the tracks in the dust and grime blown in through the open front door, numerous people and creatures came and went before you. Almost all of the shelves have been rifled through and some even knocked over, creating quite a mess in here. Empty bags of all sorts of pet food are scattered everywhere, sometimes lying in sticky pools of what is clearly cum. With the food gone and the sheer scale of the mess in here, there could be some interesting and useful items to find if one were to spend some time [link]sort[as]sort chaotic mess[end link]ing through the chaotic mess. Since digging up anything of worth will be rather work intensive, this would probably not be worth the time unless you had a use for it.";
+	say "     You're in a mid-sized pet store that has been recently looted. Judging from the tracks in the dust and grime blown in through the open front door, numerous people and creatures came and went before you. Almost all of the shelves have been rifled through and some even knocked over, creating quite a mess in here. Empty bags of all sorts of pet food are scattered everywhere, sometimes lying in sticky pools of what is clearly cum. With the food gone and the sheer scale of the mess in here, there could be some interesting and useful items to find if one were to spend some time to [link]sort[as]sort chaotic mess[end link] through the chaotic mess. Since digging up anything of worth will be rather work intensive, this would probably not be worth the time unless you had a use for it.";
 
 instead of sniffing George's Animal Emporium:
 	say "     Myriad different smells are all around you in here, wafting up from food wrappers and toys, as well as the remnants of hasty matings between previous looters and scavengers who have visited this place. Somewhere in this mess, a bag of catnip must have been torn open, its dried contents scattered all over the ground.";
+
+[The fur brush object and the chaotic mess are defined in Pet Shop]
 
 
 West of Half-Renovated Room is Breakroom.

--- a/Wahn/Pet Shop.i7x
+++ b/Wahn/Pet Shop.i7x
@@ -1,9 +1,12 @@
 Version 1 of Pet Shop by Wahn begins here.
-[ Version 1.0 - New Content by Wahn]
+[ Version 1.0 - New Content - Wahn                    ]
+[ Version 1.1 - Added missing fur brush object - Song ]
 
 "Adds content for the pet store near the Grey Abbey Library"
 
 Section 1 - Chaotic Mess
+
+[George's Animal Emporium is defined in Basic Locations]
 
 Chaotic Mess is a person. Chaotic Mess is in George's Animal Emporium.
 The description of Chaotic Mess is "     Most of George's Animal Emporium is filled with a terrible mess, as the store's contents have been rifled through multiple times already. The looters were clearly not interested in putting things back into their original positions. This has resulted in a sprawling chaos of items scattered everywhere, ankle deep in places and hip high for a human in others. If you had a specific friend or pet in mind, you could very well find them a gift or something in here. Maybe you should try to [link]sort[as]sort chaotic mess[end link] through the chaotic mess?".
@@ -55,5 +58,8 @@ the usedesc of fur brush is "[fur brush use]";
 
 to say fur brush use:
 	say "     You play around a little with the wooden brush, stroking your hand over the nubs and bristles on it. Having it along should certainly be useful if you want to give a pet or furred companion some affection. The surprisingly ergonomic handle has several prominent ridges and a smooth texture, making you think of at least one extra use for the foot-long piece of wood.";
+
+when play begins:
+	add "fur brush" to the invent of George's Animal Emporium;
 
 Pet Shop ends here.


### PR DESCRIPTION
Fixes the fur brush (and relevant content) being inaccessible due to a missing game object.

Remember to playtest to avoid bugs like these in the future. Thank you.