### PR TITLE
Small change to Fang and a Bugfix

### DIFF
--- a/Core Mechanics/Pregnancy.i7x
+++ b/Core Mechanics/Pregnancy.i7x
@@ -1085,6 +1085,7 @@ to selfimpregnate:
 			say "You choose not to accept the seed.";
 			if "Fang's Mate" is listed in feats of Player:
 				remove "Fang's Mate" from feats of Player;
+				now hp of Fang is 0;
 			stop the action;
 	now gestation of Child is a random number from 24 to 48;
 	if HeadName of Player is "" or TorsoName of Player is "" or BackName of Player is "" or ArmsName of Player is "" or LegsName of Player is "" or AssName of Player is "" or TailName of Player is "": [player doesn't have all new type parts]

--- a/Prometheus/Fang.i7x
+++ b/Prometheus/Fang.i7x
@@ -580,7 +580,7 @@ to say fangalphatrio:
 
 Chapter 2 - w/o Sandra	[Only available if 'girl' is banned, removing Sandra from the game]
 
-instead of going up from Bunker while ( lastfuck of Fang - turns >= 24 and HP of Fang is 1 and FemaleList is banned) and player is not neuter:	[ignored for 3+ days]
+instead of going up from Bunker while ( lastfuck of Fang - turns >= 24 and HP of Fang is 1) and player is not neuter:	[ignored for 3+ days]
 	now lastfuck of Fang is turns;
 	project the Figure of Fang_face_icon;
 	say "     After stepping from the bunker and closing the heavy door, you are pounced upon by something. As you start to struggle, you are surprised to find that it's Fang atop you. From his growls and the hard cock rubbing against you, you surmise that the wolf's not playing around. It's been some time since you've given the beast some attention and it looks like he's intent on satisfying his lusts with you whether you like it or not. As his throbbing shaft grinds against you while he tries to get a better grip on you, the scent from the powerful beast is quite enticing. It could be fun to just give in and let the big wolf have his way with you.";


### PR DESCRIPTION
Alpha Fang should now be able to be obtained without Sandra or banning females. Also a slight oversight in the pregnancy coding for the Fang's Mate Feat.