### PR TITLE
Fix incomplete FlightList

### DIFF
--- a/AGentlemanCalledB/Fire Sprite.i7x
+++ b/AGentlemanCalledB/Fire Sprite.i7x
@@ -259,6 +259,7 @@ When Play begins:
 	add "Fire Sprite" to infections of NonOrganicList;
 	add "Fire Sprite" to infections of NatureList;
 	add "Fire Sprite" to infections of BipedalList;
+	add "Fire Sprite" to infections of FlightList;
 	now Name entry is "Fire Sprite"; [ Infection/Creature name. Capitalized. ]
 	now enemy title entry is ""; [name of the encountered creature at combat start - Example: "You run into a giant collie." instead of using "Smooth Collie Shemale" infection name]
 	now enemy Name entry is ""; [specific name of unique enemy]

--- a/Blue Bishop/Ebonflame Dragator.i7x
+++ b/Blue Bishop/Ebonflame Dragator.i7x
@@ -116,6 +116,7 @@ When Play begins:
 	add "Ebonflame Dragator" to infections of TaperedCockList;
 	add "Ebonflame Dragator" to infections of InternalCockList;
 	add "Ebonflame Dragator" to infections of BipedalList;
+	add "Ebonflame Dragator" to infections of FlightList;
 	add "Ebonflame Dragator" to infections of TailList;
 	add "Ebonflame Dragator" to infections of TailweaponList;
 	now Name entry is "Ebonflame Dragator";

--- a/Blue Bishop/Ebonflame Drake.i7x
+++ b/Blue Bishop/Ebonflame Drake.i7x
@@ -92,6 +92,7 @@ When Play begins:
 	add "Ebonflame Drake" to infections of TaperedCockList;
 	add "Ebonflame Drake" to infections of InternalCockList;
 	add "Ebonflame Drake" to infections of BipedalList;
+	add "Ebonflame Drake" to infections of FlightList;
 	add "Ebonflame Drake" to infections of TailList;
 	add "Ebonflame Drake" to infections of TailweaponList;
 	now Name entry is "Ebonflame Drake";

--- a/Blue Bishop/Ebonflame Whelp.i7x
+++ b/Blue Bishop/Ebonflame Whelp.i7x
@@ -111,6 +111,7 @@ When Play begins:
 	add "Ebonflame Whelp" to infections of TaperedCockList;
 	add "Ebonflame Whelp" to infections of InternalCockList;
 	add "Ebonflame Whelp" to infections of BipedalList;
+	add "Ebonflame Whelp" to infections of FlightList;
 	add "Ebonflame Whelp" to infections of TailList;
 	add "Ebonflame Whelp" to infections of TailweaponList;
 	now Name entry is "Ebonflame Whelp";

--- a/Blue Bishop/Yamato Dragon.i7x
+++ b/Blue Bishop/Yamato Dragon.i7x
@@ -895,6 +895,7 @@ When Play begins:
 	add "Yamato Dragon" to infections of BarbedCockList;
 	add "Yamato Dragon" to infections of InternalCockList;
 	add "Yamato Dragon" to infections of QuadrupedalList;
+	add "Yamato Dragon" to infections of FlightList;
 	add "Yamato Dragon" to infections of TailList;
 	add "Yamato Dragon" to infections of TailweaponList;
 	now Name entry is "Yamato Dragon";

--- a/Blue Bishop/Yamato Dragoness.i7x
+++ b/Blue Bishop/Yamato Dragoness.i7x
@@ -586,6 +586,7 @@ When Play begins:
 	add "Yamato Dragoness" to infections of BarbedCockList;
 	add "Yamato Dragoness" to infections of InternalCockList;
 	add "Yamato Dragoness" to infections of QuadrupedalList;
+	add "Yamato Dragoness" to infections of FlightList;
 	add "Yamato Dragoness" to infections of TailList;
 	add "Yamato Dragoness" to infections of TailweaponList;
 	now Name entry is "Yamato Dragoness";

--- a/Rikaeus/Stewart.i7x
+++ b/Rikaeus/Stewart.i7x
@@ -35,14 +35,14 @@ instead of going Northwest from College Walkway Northwest while CloudKnowledge i
 	now CloudKnowledge is 1;
 
 instead of going Up from College Belltower:
-	if BodyName of Player is listed in infections of flightlist:
+	if BodyName of Player is listed in infections of FlightList:
 		say "     With a hard push you use your ability to fly to launch yourself into the air. When you do remove yourself from the ground your beginning flight is rather unsteady. You have to quickly correct your path so that you don't crash into the belltower itself. Once you're out of the turbulence of the tower you easily glide up to the fluffy white clouds. You reach them in no time, landing yourself on the vast expanse of surprisingly solid water vapor.";
 		move player to The Clouds;
 	else:
 		say "     You get a confused look on your face when you try to go up. What would make you think you could fly without wings or some infection that can do so without. So instead you shrug and remain where you are, unable to get to the clouds.";
 
 instead of going Down from The Clouds:
-	if BodyName of Player is listed in infections of flightlist:
+	if BodyName of Player is listed in infections of FlightList:
 		say "     With a burst of speed you run before flipping yourself off the clouds. Your ability to fly kicks in right away allowing you to hover in place. Once you've gathered your bearings you begin a dive to the ground. It's not long before you gracefully land in front of the College Belltower, leaving you to continue on your journey.";
 		move player to College Belltower;
 	else:

--- a/Stripes/Dracovixentaur.i7x
+++ b/Stripes/Dracovixentaur.i7x
@@ -145,6 +145,7 @@ When Play begins:
 	add "Dracovixentaur" to infections of TaperedCockList;
 	add "Dracovixentaur" to infections of SheathedCockList;
 	add "Dracovixentaur" to infections of TaurList;
+	add "Dracovixentaur" to infections of FlightList;
 	add "Dracovixentaur" to infections of TailList;
 	add "Dracovixentaur" to infections of TailweaponList;
 	now Name entry is "Dracovixentaur"; [ Infection/Creature name. Capitalized. ]

--- a/Stripes/Dragontaur.i7x
+++ b/Stripes/Dragontaur.i7x
@@ -69,6 +69,7 @@ When Play begins:
 	add "Dragontaur" to infections of TaperedCockList;
 	add "Dragontaur" to infections of InternalCockList;
 	add "Dragontaur" to infections of TaurList;
+	add "Dragontaur" to infections of FlightList;
 	add "Dragontaur" to infections of TailList;
 	add "Dragontaur" to infections of TailweaponList;
 	now Name entry is "Dragontaur"; [ Infection/Creature name. Capitalized. ]

--- a/Stripes/Vulpogryph.i7x
+++ b/Stripes/Vulpogryph.i7x
@@ -41,6 +41,7 @@ When Play begins:
 	add "Vulpogryph" to infections of KnottedCockList;
 	add "Vulpogryph" to infections of SheathedCockList;
 	add "Vulpogryph" to infections of BipedalList;
+	add "Vulpogryph" to infections of FlightList;
 	add "Vulpogryph" to infections of TailList;
 	now Name entry is "Vulpogryph"; [ Infection/Creature name. Capitalized. ]
 	now enemy title entry is ""; [name of the encountered creature at combat start - Example: "You run into a giant collie." instead of using "Smooth Collie Shemale" infection name]

--- a/Wahn/Seraphim.i7x
+++ b/Wahn/Seraphim.i7x
@@ -281,7 +281,7 @@ When Play begins:
 	add "Seraphim Warrior" to the infections of OtherworldlyList;
 	add "Seraphim Warrior" to the infections of MaleList;
 	add "Seraphim Warrior" to the infections of BipedalList;
-	add "Seraphim Warrior" to the infections of Flightlist;
+	add "Seraphim Warrior" to the infections of FlightList;
 	now Name entry is "Seraphim Warrior";
 	now enemy title entry is ""; [name of the encountered creature at combat start - Example: "You run into a giant collie." instead of using "Smooth Collie Shemale" infection name]
 	now enemy Name entry is "Gabriel";


### PR DESCRIPTION
### Purpose of the PR
fixes issue #2125

### Changes
- Added the missing infections to the `FlightList`.
- Fixed camel case in `Stripes/Vulpogryph.i7x` and `Wahn/Seraphim.i7x` for the sake of consistency.

### Notes
I've just did a brief test as a Dracovixentaur, but the rest should work as intended, too.