### PR TITLE
Fix CONTRIBUTING.md and sync.bat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Start by adding the linter plugin. It'll ask you to install some dependencies as
 ## 6. Install Inform 7
 Install Inform 7! Flexible Survival runs on this game engine.
 
-http://inform7.com/download/
+http://inform7.com/downloads/
 
 However, Flexible Survival is too big for Inform! We have a custom 64-bit compiler that you will also have to install or else you will not be able to compile the game:
 
@@ -75,6 +75,7 @@ You will have to do this step every time a new folder is introduced (either pull
 It will make a symlink from your Inform project to the Github repo, so that the Inform engine knows where the files are stored for compilation.
 
 Here are the manual mapping of files if you do not want to use the script:
+
 | Action                      | File/Folder                        | At  |
 | --------------------------- | ---------------------------------- | --- |
 | Copy the file from the folder `Documents\Github\Inform` | `story.ni` | `Documents\Inform\Projects\Flexible Survival.inform\Source` |

--- a/sync.bat
+++ b/sync.bat
@@ -27,24 +27,24 @@ if '%errorlevel%' NEQ '0' (
 echo [INFO] Starting...
 
 echo [INFO] Making symlink for .ctags in User folder
-fsutil reparsepoint query "%HOMEPATH%\.ctags" | find "Symbolic Link" >nul && (
+fsutil reparsepoint query "%USERPROFILE%\.ctags" | find "Symbolic Link" >nul && (
   echo [INFO]   Removing existing symlink...
-  del "%HOMEPATH%\.ctags"
+  del "%USERPROFILE%\.ctags"
 ) || (
   echo [INFO]   Backing up .ctags
-  move /Y "%HOMEPATH%\.ctags" "%HOMEPATH%\.ctags_old"
+  move /Y "%USERPROFILE%\.ctags" "%USERPROFILE%\.ctags_old"
 )
-mklink "%HOMEPATH%\.ctags" "%HOMEPATH%\Documents\Github\Flexible-Survival\.ctags"
+mklink "%USERPROFILE%\.ctags" "%USERPROFILE%\Documents\Github\Flexible-Survival\.ctags"
 
 echo [INFO] Making symlink for .story.ni in Inform folder
-fsutil reparsepoint query "%HOMEPATH%\Documents\Inform\Projects\Flexible Survival.inform\Source\story.ni" | find "Symbolic Link" >nul && (
+fsutil reparsepoint query "%USERPROFILE%\Documents\Inform\Projects\Flexible Survival.inform\Source\story.ni" | find "Symbolic Link" >nul && (
   echo [INFO]   Removing existing symlink...
-  del "%HOMEPATH%\Documents\Inform\Projects\Flexible Survival.inform\Source\story.ni"
+  del "%USERPROFILE%\Documents\Inform\Projects\Flexible Survival.inform\Source\story.ni"
 ) || (
   echo [INFO]   Backing up story.ni
-  move /Y "%HOMEPATH%\Documents\Inform\Projects\Flexible Survival.inform\Source\story.ni" "%HOMEPATH%\Documents\Inform\Projects\Flexible Survival.inform\Source\story_old.ni"
+  move /Y "%USERPROFILE%\Documents\Inform\Projects\Flexible Survival.inform\Source\story.ni" "%USERPROFILE%\Documents\Inform\Projects\Flexible Survival.inform\Source\story_old.ni"
 )
-mklink "%HOMEPATH%\Documents\Inform\Projects\Flexible Survival.inform\Source\story.ni" "%HOMEPATH%\Documents\Github\Flexible-Survival\Inform\story.ni"
+mklink "%USERPROFILE%\Documents\Inform\Projects\Flexible Survival.inform\Source\story.ni" "%USERPROFILE%\Documents\Github\Flexible-Survival\Inform\story.ni"
 
 echo [INFO] Making symlink for .gblorb in Program Files folder
 fsutil reparsepoint query "%PROGRAMFILES(X86)%\Silver Games LLC\flexible\Flexible Survival\Release\Flexible Survival.gblorb" | find "Symbolic Link" >nul && (
@@ -54,14 +54,14 @@ fsutil reparsepoint query "%PROGRAMFILES(X86)%\Silver Games LLC\flexible\Flexibl
   echo [INFO]   Backing up .gblorb
   move /Y "%PROGRAMFILES(X86)%\Silver Games LLC\flexible\Flexible Survival\Release\Flexible Survival.gblorb" "%PROGRAMFILES(X86)%\Silver Games LLC\flexible\Flexible Survival\Release\Flexible Survival_old.gblorb"
 )
-mklink "%PROGRAMFILES(X86)%\Silver Games LLC\flexible\Flexible Survival\Release\Flexible Survival.gblorb" "%HOMEPATH%\Documents\Inform\Projects\Flexible Survival.materials\Release\Flexible Survival.gblorb"
+mklink "%PROGRAMFILES(X86)%\Silver Games LLC\flexible\Flexible Survival\Release\Flexible Survival.gblorb" "%USERPROFILE%\Documents\Inform\Projects\Flexible Survival.materials\Release\Flexible Survival.gblorb"
 
 echo [INFO] Making Flexible Survival.materials folder in Inform folder
-mkdir "%HOMEPATH%\Documents\Inform\Projects\Flexible Survival.materials"
+mkdir "%USERPROFILE%\Documents\Inform\Projects\Flexible Survival.materials"
 
 echo [INFO] Making symlink for Figures folder in Inform folder
-rmdir /S /Q "%HOMEPATH%\Documents\Inform\Projects\Flexible Survival.materials\Figures"
-mklink /D "%HOMEPATH%\Documents\Inform\Projects\Flexible Survival.materials\Figures" "%HOMEPATH%\Documents\Github\Flexible-Survival\Figures"
+rmdir /S /Q "%USERPROFILE%\Documents\Inform\Projects\Flexible Survival.materials\Figures"
+mklink /D "%USERPROFILE%\Documents\Inform\Projects\Flexible Survival.materials\Figures" "%USERPROFILE%\Documents\Github\Flexible-Survival\Figures"
 
 echo [INFO] Making symlink for all folders that are not Inform or Figures into the Inform extensions folder
 for /d %%D in (*) do (
@@ -75,8 +75,8 @@ for /d %%D in (*) do (
         echo [INFO]   * Skipping Figures folder
       ) ELSE (
         echo [INFO]   Making symlink for %%D
-        rmdir /S /Q "%HOMEPATH%\Documents\Inform\Extensions\%%D"
-        mklink /D "%HOMEPATH%\Documents\Inform\Extensions\%%D" "%HOMEPATH%\Documents\Github\Flexible-Survival\%%D"
+        rmdir /S /Q "%USERPROFILE%\Documents\Inform\Extensions\%%D"
+        mklink /D "%USERPROFILE%\Documents\Inform\Extensions\%%D" "%USERPROFILE%\Documents\Github\Flexible-Survival\%%D"
       )
     )
   )


### PR DESCRIPTION
### Purpose of this PR
The manual on how to contribute didn't work anymore and `sync.bat` created broken symlinks.

### Changes
#### CONTRIBUTING.md
- The download link for Inform 7 was broken. Fixed that.
- Also fixed the borked table.

#### sync.bat
The symlink to `Flexible Survival.gblorb` was broken, because `%HOMEPATH%` didn't contain the drive-letter. Replaced all occurrences of `%HOMEPATH%`  with `%USERPROFILE%` to fix that.

### Note
I only did a brief test. This might be needed to be tested with a fresh development environment.