### PR TITLE
Restore changing character icons on import

### DIFF
--- a/Core Mechanics/Story Skipper.i7x
+++ b/Core Mechanics/Story Skipper.i7x
@@ -690,6 +690,19 @@ to NoteRestore:
 	else:
 		say "No Note Save File Found!";
 
+to CharacterIconRestore:
+	say "Restoring Character Icons...";
+	AlexIconRestore;
+	HadiyaIconRestore;
+	LeonardIconRestore;
+	RodAndRondaIconRestore;
+	SamIconRestore;
+	ChrisIconRestore;
+	DemonBruteIconRestore;
+	DiegoIconRestore;
+	JayIconRestore;
+	DrMattIconRestore;
+
 Section 2 - Trixie
 
 understand "export progress" as ProgressExport.
@@ -743,6 +756,7 @@ to say ProgressionImport:
 	BeastRestore;
 	NoteRestore;
 	VariableLoad;
+	CharacterIconRestore;
 
 Table of GameCharacterIDs (continued)
 object	name

--- a/Stripes/Alex.i7x
+++ b/Stripes/Alex.i7x
@@ -17,6 +17,10 @@ gettinglee is a number that varies.
 
 the scent of Alex is "[alexscent]".
 
+to AlexIconRestore:
+	if alexbrunch >= 4:
+		now the icon of Alex is Figure of Alex_icon;
+
 to say alexscent:
 	if alexbrunch < 4:
 		say "Alex smells like a mix of human and ferret.";

--- a/Stripes/Leonard.i7x
+++ b/Stripes/Leonard.i7x
@@ -58,6 +58,10 @@ feline_pride_defeat is a truth state that varies. feline_pride_defeat is usually
 
 the scent of Leonard is "The feline smells strong and manly.".
 
+to LeonardIconRestore:
+	if HP of Leonard >= 6:
+		now the icon of Leonard is the figure of LeonardViolin_icon;
+
 to say Leonarddesc:
 	say "     Leonard is a lion-man like those you've seen in the park, but well-groomed and well-mannered. He has a strong, manly chest, which he loosely covers with his suit coat. While it could probably close, it certainly seems more comfortable open[if leopocketwatch is true]. He keeps an antique gold pocket watch in the breast pocket[end if]. He is covered in tawny fur and has a large, russet mane. His lower body is unclothed, leaving his sheath and plump balls exposed.";
 

--- a/Stripes/Main Storyline.i7x
+++ b/Stripes/Main Storyline.i7x
@@ -17,6 +17,10 @@ understand "Matt" as Doctor Matt.
 understand "Left Behind Recording of Doctor Matt " as Doctor Matt.
 the icon of Doctor Matt is figure of DrMatt_face_icon.
 
+to DrMattIconRestore:
+	if HP of Doctor Matt is 100:
+		now the icon of Doctor Matt is figure of pixel;
+
 to say DrMattDesc:
 	if debugactive is 1:
 		say "DEBUG -> HP: [HP of Doctor Matt] <- DEBUG[line break]";

--- a/Stripes/RodAndRonda.i7x
+++ b/Stripes/RodAndRonda.i7x
@@ -119,6 +119,12 @@ The description of Ronda Mallrat is "[rondadesc]".
 The conversation of Ronda is { "empty" }.
 Ronda Mallrat is in Mall Atrium.
 
+to RodAndRondaIconRestore:
+	if HP of Ronda is 100:
+		now the icon of Rod Mallrat is figure of pixel;
+		now the icon of Ronda is figure of RondaSR_icon;
+
+
 to say rondadesc:
 	if HP of Ronda is 0:
 		say "You have no idea if she was shapely before her infection, but she is now, with wide hips, narrow waist, and the latest of mall rat fashions. She wears a bright button that declares, 'I am a taken girl.' Aww. Her naked pink tail flickers with an unending energy as she looks about with active interest. Her lips are stained a deep red and her claws are all manicured and covered in sparkling motes. She takes care of herself, clearly. Even her white and spotted fur is glossy and healthy looking.";

--- a/Stripes/Sam.i7x
+++ b/Stripes/Sam.i7x
@@ -128,6 +128,12 @@ The conversation of Sam is { "Thanks." }.
 the scent of Sam is "[samscent]".
 samformtalk is a truth state that varies. samformtalk is usually false.
 
+to SamIconRestore:
+	if HP of Sam >= 30 and HP of Sam <= 49:
+		now icon of Sam is figure of Vixentaur_icon;
+	else if HP of Sam >= 50 and HP of Sam <= 69:
+		now icon of Sam is figure of Dracovixentaur_icon;
+
 to say samscent:
 	if HP of Sam <= 4:
 		say "Sam himself smells human, though there is the lingering scent of several of his recent [']sample donors['] as well.";

--- a/Stripes/hadiya.i7x
+++ b/Stripes/hadiya.i7x
@@ -97,6 +97,10 @@ The fuckscene of Hadiya is "[sexwithHadiya]".
 the icon of Hadiya is usually Figure of Hadiya_0_icon.
 hgsqc is a number that varies.
 
+to HadiyaIconRestore:
+	if HP of Hadiya is 11 or HP of Hadiya is 12 or HP of Hadiya >= 61:
+		now the icon of Hadiya is Figure of Hadiya_icon;
+
 to say hadiyadesc:
 	if debugactive is 1:
 		say "DEBUG (Hadiya) -> HP: [HP of Hadiya], hadiyafucked: [hadiyafucked], lastfuck: [lastfuck of Hadiya], Hyena Gang ref: [if hadiyahyg is true]Y[else]N[end if] <- DEBUG[line break]";

--- a/Wahn/Chris.i7x
+++ b/Wahn/Chris.i7x
@@ -71,6 +71,12 @@ ChrisPlayerOffspring is a number that varies.
 instead of sniffing Chris:
 	say "     Chris has got an attractive male scent.";
 
+to ChrisIconRestore:
+	if Libido of Chris is 2:
+		now the icon of Chris is Figure of OrcWarrior_random_icon;
+	else if Libido of Chris is 1:
+		now the icon of Chris is Figure of OrcBreeder_random_icon;
+
 to say ChrisDesc:
 	if debugactive is 1:
 		say "DEBUG -> HP: [HP of Chris]; Strength of Chris: [Strength of Chris]; Intelligence of Malik: [Intelligence of Malik]; Libido of Malik: [Libido of Malik]<- DEBUG[line break]";

--- a/Wahn/Demon Brute.i7x
+++ b/Wahn/Demon Brute.i7x
@@ -37,6 +37,10 @@ to say demonbrutedesc:
 	else:
 		say "You see a massive beast ahead, with dark purple skin, a frightening face with slits for nostrils, yellow eyes with red irises, and sharp, intimidating teeth. Three matched pairs of horns crown his head, curved and getting smaller front to back. His entire body is gigantic and muscle-bound, and between his legs hangs a thick cock, flaccid for the time being. Behind that, his massive pair of balls dangle, swollen with cum. He also has a long, spade-tipped tail protruding from his tailbone, which is constantly flicking back and forth. He wears nothing but a grin.";
 
+to DemonBruteIconRestore:
+	if DBCaptureQuestVar is 6 or DBCaptureQuestVar is 7: [cleansed]
+		now the icon of demon brute is Figure of BrutusGood_icon;
+
 to say demon brute wins:
 	if inasituation is true:
 		say ""; [dealt with at the source]

--- a/Wahn/Diego.i7x
+++ b/Wahn/Diego.i7x
@@ -39,6 +39,12 @@ The icon of Diego is Figure of Diego_icon.
 
 the linkaction of Diego is "[diegolinkaction]".
 
+to DiegoIconRestore:
+	if DiegoChanged is 2:
+		now the icon of Diego is Figure of DiegoFem_icon;
+	else if DiegoChanged is 1:
+		now the icon of Diego is Figure of pixel_icon;
+
 to say diegolinkaction:
 	if DiegoTalk is 0:
 		say "Possible Actions: [link]talk[as]talk Diego[end link], [link]smell[as]smell Diego[end link], [link]fuck[as]fuck Diego[end link][line break]";

--- a/Wahn/Jay.i7x
+++ b/Wahn/Jay.i7x
@@ -41,6 +41,10 @@ The conversation of Jay is { "<This is nothing but a placeholder!>" }.
 The icon of Jay is Figure of Jay_elf_outfit_icon.
 The scent of Jay is "     Jay must wash regularly, as there is little discernible odor to his skin. What you do detect are motes of cinnamon, spices and a hint of gingerbread, the aroma complementing his appearance. There's also a faint trace of his ursine partner's musk, no doubt courtesy of their frequent lovemaking.".
 
+to JayIconRestore:
+	if thirst of Jay is 9: [suit delivered]
+		now the icon of Jay is Figure of Jay_suit_icon;
+
 to say JayDesc:
 	if debugactive is 1:
 		say "DEBUG -> Thirst: [thirst of Jay], JayMarkRelationship: [JayMarkRelationship], XP: [XP of Jay] <- DEBUG[line break]";


### PR DESCRIPTION
### Purpose of this PR
A handful of NPCs, like Sam have changing icons aka images depending on your playthrough. These images aren't exported, when you're exporting the game to a newer version. Sam for example resulted in a black image after import.

#### Steps to reproduce:
1. Open a save with Sam being a vixentaur or dracovixentaur,
2. Move to the large shed and 'look at Sam' to confirm, that the image is shown.
3. Export the game.
4. Restart the game.
5. Import the exported game.

#### Result
When looking at Sam it shows just a black image.

### Changes
I've grepped through the source to find all culprits
```sh
grep -P --color=auto --exclude-dir=.git -rni "now (?:the )?icon of .+ is" .
```
... and added an `XyzIconRestore` function (aka phrase IIRC) to fix this.

### Notes
So far I've only tested Sam. But the rest compiles too. And so far I couldn't find any flaw by looking on the code my changes here. However, it would be neat if someone could check a few of the other characters,