### PR TITLE
.ctags update

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -1,12 +1,12 @@
 --langdef=Inform
 --langmap=Inform:.i7x.ni
 --regex-Inform=/^\s*(.+?) ?is a (number|truth state) that/\1/f,func/
---regex-Inform=/^\s*(.+?) ?is text that/\1/f,func/
+--regex-Inform=/^\s*(.+?) ?is (a )?text that/\1/f,func/
 --regex-Inform=/^\s*(.+?) ?is a (situation|scavevent)/\1/f,func/
---regex-Inform=/^\s*to say ?(.+?) ?:/\1/f,func/
+--regex-Inform=/^\s*to (say )?([^(]+?).*? ?:/\2/f,func/
 --regex-Inform=/^\s*carry out ?(.+?):]/\1/f,func/
 --regex-Inform=/^\s*Definition: A person ?(.+?) ?is ([^\[]+):/\2/f,func/
---regex-Inform=/^\s*(.+?) ?is a (woman|man)/\1/f,func/
+--regex-Inform=/^\s*([^"()]+?) ?is a (woman|man)/\1/f,func/
 --regex-Inform=/^\s*instead of ?(.+?):/\1/f,func/
---regex-Inform=/^\s*(.+?) ?is a room/\1/f,func/
+--regex-Inform=/^\s*([^"()]+?) ?is a room/\1/f,func/
 --regex-Inform=/^\s*This is the (.+?) rule:/\1/f,func/


### PR DESCRIPTION
### Purpose of this PR
Updated `.ctags`, so the regexes match more, that they should match and fix some to be less greedy.

### Changes
The diff explained line by line:
1. ```diff
   ---regex-Inform=/^\s*(.+?) ?is text that/\1/f,func/
   +--regex-Inform=/^\s*(.+?) ?is (a )?text that/\1/f,func/
   ```
   Should be self explanatory. Now it matches `blah is text that` **and** `blah is a text that`.

2. ```diff
   ---regex-Inform=/^\s*to say ?(.+?) ?:/\1/f,func/
   +--regex-Inform=/^\s*to (say )?([^(]+?).*? ?:/\2/f,func/
   ```
   For one this now matches `to blah` functions too and not just `to say blah` functions. In addition I made the regex less greedy, so that for example `to setmonster ( x - text )` is matched as `setmonster` and not as `setmonster ( x - text )` for the function name.

3. ```diff
   ---regex-Inform=/^\s*(.+?) ?is a (woman|man)/\1/f,func/
   +--regex-Inform=/^\s*([^"()]+?) ?is a (woman|man)/\1/f,func/
    --regex-Inform=/^\s*instead of ?(.+?):/\1/f,func/
   ---regex-Inform=/^\s*(.+?) ?is a room/\1/f,func/
   +--regex-Inform=/^\s*([^"()]+?) ?is a room/\1/f,func/
   ```
   Made these regexes less greedy too. Before that I had matches like for example:
   ```
   say "     blah, blah, yadda, yadda ... Standing there is a woman ...
   ```
   where everything before `is a woman` was matched as a 'function' or 
   ```
   Pediatrics Lobby is a room. "     blah, blah, yadda, yadda ... Standing there is a woman ...
   ```
   Where the same happened. Now the latter should match `Pediatrics Lobby` as the room name correctly.

### Notes
Did some brief tests running Atom Ctags: Rebuild a couple time and it looks fine so far, though I haven't checked if it misses a couple functions, that it didn't mess before.
The drawback is, that Atom Ctags: Rebuild *might* take longer to finish so you might wanna adjust the Build Timeout-setting for Atom Ctags. btw: The default of that setting is currently 10000ms aka 10s, so you might wanna point ppl. to that setting in [CONTRIBUTING.md](https://github.com/Nuku/Flexible-Survival/blob/master/CONTRIBUTING.md).

### Discord handle
Stadler#3007