### PR TITLE
Use CreaturSexAfterMath for Wyvern sex

### DIFF
--- a/Damaged/Wyvern.i7x
+++ b/Damaged/Wyvern.i7x
@@ -167,7 +167,12 @@ to say WYVVIC:
 			else:
 				say "you're railed by the relentlessly eager wyvern for what seems like forever, finally letting out an ear-splitting screech in bliss. At first, the initial gouts of the beast's thick, virile seed are slow, but they very quickly intensify until it feels like you're being utterly hosed by them, [if scalevalue of Player < 4]forced to watch each gout balloons out your stomach even further[else if scalevalue of Player is 4]visibly swelling with each gout[else]wholly filling you[end if] until it sputters from your hole. The sensation is intense enough that you're driven to cry out in your own orgasm, [if Cock Count of Player > 1]cocks smearing their [Cum Load Size of Player] load against both your torsos[else if Player is male]cock smearing its [Cum Load Size of Player] load across both your torsos[else]strained hole milking its invading organ[end if], not that the beast even seems to notice.";
 			if boundstate is true:
-				say "     Suddenly, and with barely any restraint, the massive reptile wrenches its dick from of you, a flood of seed oozing from your gaping hole in its wake, briefly minding his twisted offspring before he takes to flight once more. Barely given a moment to recover, the wyvern kin climb onto you again, reassuming their prior positions, no doubt eager to resume, their own lust heightened from the show.[ovichance][line break]";
+				say "     Suddenly, and with barely any restraint, the massive reptile wrenches its dick from of you, a flood of seed oozing from your gaping hole in its wake, briefly minding his twisted offspring before he takes to flight once more. Barely given a moment to recover, the wyvern kin climb onto you again, reassuming their prior positions, no doubt eager to resume, their own lust heightened from the show.";
+				if Player is female:
+					CreatureSexAftermath "Player" receives "PussyFuck" from "Wyvern";
+				else:
+					CreatureSexAftermath "Player" receives "AssFuck" from "Wyvern";
+				LineBreak;
 				if Libido of Player > 25, decrease Libido of Player by (Libido of Player / 10) + 1;
 				now lustatt is Libido of Player;
 				if struggleatt > 0, decrease struggleatt by 1;
@@ -180,7 +185,12 @@ to say WYVVIC:
 				if wyvkinocc > 0, increase wyvkin3lib by 5;
 				if wyvkinocc > 0, increase wyvkin4lib by 5;
 			else:
-				say "     Suddenly, and with barely any restraint, the massive reptile wrenches its dick from of you, a flood of seed oozing from your gaping hole in its wake, before billowing you with a gust of wind as it takes to the air again, abandoning your still-bound form and only appearing marginally satisfied. The whole ordeal probably scared off any locals, because you're given a fair amount of time to recover and slowly pull the goop free of you, getting back up and slowly limping off.[ovichance][line break]";
+				say "     Suddenly, and with barely any restraint, the massive reptile wrenches its dick from of you, a flood of seed oozing from your gaping hole in its wake, before billowing you with a gust of wind as it takes to the air again, abandoning your still-bound form and only appearing marginally satisfied. The whole ordeal probably scared off any locals, because you're given a fair amount of time to recover and slowly pull the goop free of you, getting back up and slowly limping off.";
+				if Player is female:
+					CreatureSexAftermath "Player" receives "PussyFuck" from "Wyvern";
+				else:
+					CreatureSexAftermath "Player" receives "AssFuck" from "Wyvern";
+				LineBreak;
 		else if anallevel > 1 and (scalevalue of Player > 3 or (scalevalue of Player is 3 and player is twistcapped)) and (Cunt Count of Player is 0 or anallevel is 3) and (a random chance of 1 in 2 succeeds or (anallevel is 3 and a random chance of 1 in 3 succeeds)):
 			if boundstate is false:
 				say ". The monster circles around you for a moment, intent on asserting his dominance by screeching at you as he eyes you over.";
@@ -197,7 +207,9 @@ to say WYVVIC:
 				else:
 					say ". Without an outlet, you are forced to struggle against this twisted, wanton fervor, not that the beast cares about or even notices your plight.";
 			if boundstate is true:
-				say "     Suddenly, and with barely any restraint, the massive reptile wrenches its dick from of you, a flood of seed oozing from your gaping hole in its wake, briefly minding his twisted offspring before he takes to flight once more. Barely given a moment to recover, the wyvern kin climb onto you again, reassuming their prior positions, no doubt eager to resume, their own lust heightened from the show.[movichance][line break]";
+				say "     Suddenly, and with barely any restraint, the massive reptile wrenches its dick from of you, a flood of seed oozing from your gaping hole in its wake, briefly minding his twisted offspring before he takes to flight once more. Barely given a moment to recover, the wyvern kin climb onto you again, reassuming their prior positions, no doubt eager to resume, their own lust heightened from the show.";
+				CreatureSexAftermath "Player" receives "AssFuck" from "Wyvern";
+				LineBreak;
 				if Player is not neuter:
 					if Libido of Player > 25, decrease Libido of Player by (Libido of Player / 10) + 1;
 					now lustatt is Libido of Player;
@@ -211,7 +223,9 @@ to say WYVVIC:
 					if wyvkinocc > 0, increase wyvkin3lib by 5;
 					if wyvkinocc > 0, increase wyvkin4lib by 5;
 			else:
-				say "     Suddenly, and with barely any restraint, the massive reptile wrenches its dick from of you, a flood of seed oozing from your gaping hole in its wake, before billowing you with a gust of wind as it takes to the air again, abandoning your still-bound form and only appearing marginally satisfied. The whole ordeal probably scared off any locals, because you're given a fair amount of time to recover and slowly pull the goop free of you, getting back up and slowly limping off.[movichance][line break]";
+				say "     Suddenly, and with barely any restraint, the massive reptile wrenches its dick from of you, a flood of seed oozing from your gaping hole in its wake, before billowing you with a gust of wind as it takes to the air again, abandoning your still-bound form and only appearing marginally satisfied. The whole ordeal probably scared off any locals, because you're given a fair amount of time to recover and slowly pull the goop free of you, getting back up and slowly limping off.";
+				CreatureSexAftermath "Player" receives "AssFuck" from "Wyvern";
+				LineBreak;
 		else:
 			if boundstate is false:
 				say ". The monster circles around you for a moment, intent on asserting his dominance by screeching at you as he eyes you over.";
@@ -536,7 +550,12 @@ to say wyvmale_1: [Cunt Catching]
 			say "     At the very last second, you pull free of the monster's dick, pulling to grind your crotch against it for a few brief seconds before its owner roars out, painting the beast in his own, voluminous seed. Succumbing to your own bliss, [if Cock Count of Player > 1]your cocks fire off your [Cum Load Size of Player] load, staining the beast's scales along with his own[else if Cock Count of Player is 1]your cock fires off your [Cum Load Size of Player] load, staining the beast's scales along with his own[else]your cunt[sfn] aching and staining the dragon's scales with your sexual fluids, mixing with his own[end if].";
 			now tempnum is 0;
 	else:
-		say "     With one final plunge, you hilt the monster's dick within you[if scalevalue of Player < 5] to the best of your ability[end if], more than enough to make its owner roar out, assaulting you with gout after successive gout flooding your womb[if scalevalue of Player < 5], causing your body to visibly bloat until it sputters from your stuffed hole[else]until it begins to ooze from your stuffed hole[end if]. Succumbing to your own bliss, [if Cock Count of Player > 1]your own cocks fire off your [Cum Load Size of Player] load, staining the beast's scales[else if Cock Count of Player is 1]your own cock fires off your [Cum Load Size of Player] load, staining the beast's scales[else if Player is female]your stuffed cunt squeezing hungrily around the throbbing organ[end if].[ovichance][line break]";
+		say "     With one final plunge, you hilt the monster's dick within you[if scalevalue of Player < 5] to the best of your ability[end if], more than enough to make its owner roar out, assaulting you with gout after successive gout flooding your womb[if scalevalue of Player < 5], causing your body to visibly bloat until it sputters from your stuffed hole[else]until it begins to ooze from your stuffed hole[end if]. Succumbing to your own bliss, [if Cock Count of Player > 1]your own cocks fire off your [Cum Load Size of Player] load, staining the beast's scales[else if Cock Count of Player is 1]your own cock fires off your [Cum Load Size of Player] load, staining the beast's scales[else if Player is female]your stuffed cunt squeezing hungrily around the throbbing organ[end if].";
+		if Player is female:
+			CreatureSexAftermath "Player" receives "PussyFuck" from "Wyvern";
+		else:
+			CreatureSexAftermath "Player" receives "AssFuck" from "Wyvern";
+		LineBreak;
 		now tempnum is 0;
 	say "     Taking a moment to catch your breath, you eventually pull yourself free of the wyvern and his tool, its audible departure from your ass loudly echoing through the air. You set him off with a smack, though his lingering exhaustion makes him slow to comply. Satisfied, you go on your merry way... Though now perhaps a little sore from the whole affair[if tempnum is 1], to say nothing of being a cum-drenched mess[end if].";
 
@@ -559,7 +578,8 @@ to say wyvmale_2: [Anal Catching]
 			say "     At the very last second, you pull free of the monster's dick, pulling to grind your crotch against it for a few brief seconds before its owner roars out, painting the beast in his own, voluminous seed. Succumbing to your own bliss, [if Cock Count of Player > 1]your cocks fire off your [Cum Load Size of Player] load, staining the beast's scales along with his[else if Cock Count of Player is 1]your cock fires off your [Cum Load Size of Player] load, staining the beast's scales along with his[else if Cunt Count of Player > 1]your cunts aching and staining the dragon's scales with your sexual fluids, mixing with his own[else]body writhing and twisting in insatiable need[end if].";
 			now tempnum is 0;
 	else:
-		say "     With one final plunge, you hilt the monster's dick within you[if scalevalue of Player < 5] to the best of your ability[end if], more than enough to make its owner roar out, assaulting you with gout after successive gout flooding your bowels[if scalevalue of Player < 5], causing your body to visibly bloat until it sputters from your stuffed hole[else]until it begins to ooze from your stuffed hole[end if]. Succumbing to your own bliss, [if Cock Count of Player > 1]your cocks fire off your [Cum Load Size of Player] load, staining the beast's scales[else if Cock Count of Player is 1]your cock fires off your [Cum Load Size of Player] load, staining the beast's scales[else if Cunt Count of Player > 1]your cunts aching and staining the dragon's scales with your sexual fluids[else]body writhing and twisting in insatiable need[end if].[movichance]";
+		say "     With one final plunge, you hilt the monster's dick within you[if scalevalue of Player < 5] to the best of your ability[end if], more than enough to make its owner roar out, assaulting you with gout after successive gout flooding your bowels[if scalevalue of Player < 5], causing your body to visibly bloat until it sputters from your stuffed hole[else]until it begins to ooze from your stuffed hole[end if]. Succumbing to your own bliss, [if Cock Count of Player > 1]your cocks fire off your [Cum Load Size of Player] load, staining the beast's scales[else if Cock Count of Player is 1]your cock fires off your [Cum Load Size of Player] load, staining the beast's scales[else if Cunt Count of Player > 1]your cunts aching and staining the dragon's scales with your sexual fluids[else]body writhing and twisting in insatiable need[end if].";
+		CreatureSexAftermath "Player" receives "AssFuck" from "Wyvern";
 		now tempnum is 0;
 	say "     Taking a moment to catch your breath, you eventually pull yourself free of the wyvern and his tool, its audible departure from your ass loudly echoing through the air. You set him off with a smack, though his lingering exhaustion makes him slow to comply. Satisfied, you go on your merry way... Though now perhaps a little sore from the whole affair[if tempnum is 1], to say nothing of being a cum-drenched mess[end if].";
 
@@ -655,6 +675,7 @@ When Play begins:
 	add "Wyvern" to infections of FlightList;
 	add "Wyvern" to infections of TailList;
 	add "Wyvern" to infections of TailweaponList;
+	add "Wyvern" to infections of OviImpregnatorList;
 	now Name entry is "Wyvern"; [Name of your new Monster]
 	now enemy title entry is ""; [name of the encountered creature at combat start - Example: "You run into a giant collie." instead of using "Smooth Collie Shemale" infection name]
 	now enemy Name entry is ""; [specific name of unique enemy]
@@ -1607,9 +1628,9 @@ to wyvernkinlustcheck:
 			else:
 				say "! Even though [if wyvkinocc > 1]the lack of room forces them to simply watch[else]they're simply watching[end if] the whole scene, it's enough for them to get off, impotently staining the nest with their sex";
 			if wyvkin1att is 5:
-				say "[ovichance]";
+				CreatureSexAftermath "Player" receives "PussyFuck" from "Wyvern";
 			else if wyvkin1att is 6:
-				say "[movichance]";
+				CreatureSexAftermath "Player" receives "AssFuck" from "Wyvern";
 			if wyvkin1att > 0:
 				increase lustatt by 10 + (lustadjust * 2);
 				increase wyvkin2lib by 20;
@@ -1662,9 +1683,9 @@ to wyvernkinlustcheck:
 			else:
 				say "! Even though [if wyvkinocc > 1]the lack of room forces them to simply watch[else]they're simply watching[end if] the whole scene, it's enough for them to get off, impotently staining the nest with their sex";
 			if wyvkin2att is 5:
-				say "[ovichance]";
+				CreatureSexAftermath "Player" receives "PussyFuck" from "Wyvern";
 			else if wyvkin2att is 6:
-				say "[movichance]";
+				CreatureSexAftermath "Player" receives "AssFuck" from "Wyvern";
 			if wyvkin2att > 0:
 				increase lustatt by 10 + (lustadjust * 2);
 				increase wyvkin1lib by 20;
@@ -1717,9 +1738,9 @@ to wyvernkinlustcheck:
 			else:
 				say "! Even though [if wyvkinocc > 1]the lack of room forces them to simply watch[else]they're simply watching[end if] the whole scene, it's enough for them to get off, impotently staining the nest with their sex";
 			if wyvkin3att is 5:
-				say "[ovichance]";
+				CreatureSexAftermath "Player" receives "PussyFuck" from "Wyvern";
 			else if wyvkin3att is 6:
-				say "[movichance]";
+				CreatureSexAftermath "Player" receives "AssFuck" from "Wyvern";
 			if wyvkin3att > 0:
 				increase lustatt by 10 + (lustadjust * 2);
 				increase wyvkin1lib by 20;
@@ -1772,9 +1793,9 @@ to wyvernkinlustcheck:
 			else:
 				say "! Even though [if wyvkinocc > 1]the lack of room forces them to simply watch[else]they're simply watching[end if] the whole scene, it's enough for them to get off, impotently staining the nest with their sex";
 			if wyvkin4att is 5:
-				say "[ovichance]";
+				CreatureSexAftermath "Player" receives "PussyFuck" from "Wyvern";
 			else if wyvkin4att is 6:
-				say "[movichance]";
+				CreatureSexAftermath "Player" receives "AssFuck" from "Wyvern";
 			if wyvkin4att > 0:
 				increase lustatt by 10 + (lustadjust * 2);
 				increase wyvkin1lib by 20;


### PR DESCRIPTION
### Purpose of this PR
This is more or less a POC, since direct use of impregchance/ovichance and so on is deprecated in favor of `CreatureSexAftermath` and `NPCSexAftermath`.

### Changes
- Use CreatureSexAftermath where the Player is on the receiving end.
- Added `add "Wyvern" to infections of OviImpregnatorList;`

### Notes
I wanted to start with Wyverns as an usage example. If I'm in the mood of digging more into the spaghetticode with scattered `tempnum`s I'd push that in another commit to this PR.