### PR TITLE
StatChange fixes

### DIFF
--- a/Core Mechanics/Basic Functions.i7x
+++ b/Core Mechanics/Basic Functions.i7x
@@ -489,11 +489,18 @@ to CreatureSexAftermath (TakingCharName - a text) receives (SexAct - a text) fro
 					now FirstOralPartner of TakingChar is GivingCharName;
 
 to StatChange (Statname - a text) by (Modifier - a number):
+	StatChange Statname by Modifier silence state is 0;
+
+to StatChange (Statname - a text) by (Modifier - a number) silently:
+	StatChange Statname by Modifier silence state is 1;
+
+to StatChange (Statname - a text) by (Modifier - a number) silence state is (Silence - a number):
 	if Modifier is 0:
 		say "ERROR: You just got a 0 point stat change. Please report on the FS Discord how you saw this.";
 	now Statname is Statname in lower case;
 	let AbsMod be absolute value of Modifier to the nearest whole number;
-	say "[bold type]Your [statname] has [if Modifier > 0]in[else]de[end if]creased by [AbsMod]![roman type][line break]";
+	if Silence is 0:
+		say "[bold type]Your [statname] has [if Modifier > 0]in[else]de[end if]creased by [AbsMod]![roman type][line break]";
 	if Statname is:
 		-- "strength":
 			increase strength of Player by Modifier;
@@ -517,6 +524,8 @@ to StatChange (Statname - a text) by (Modifier - a number):
 			increase intelligence of Player by Modifier;
 		-- "perception":
 			increase perception of Player by Modifier;
+		-- otherwise:
+			say "ERROR: Invalid stat '[Statname]' used in StatChange. Please report on the FS Discord how you saw this.";
 [
 understand "teststatgain" as StatGainAction.
 

--- a/Core Mechanics/Settings Menus.i7x
+++ b/Core Mechanics/Settings Menus.i7x
@@ -158,12 +158,12 @@ carry out Trixiecheating:
 				if "Well Rested" is listed in feats of Player: [They have slept recently, reduce/remove feat.]
 					FeatLoss "Well Rested";
 					say "     Due to activating [bold type]Insomniac[roman type] You have lost the 'Well Rested' Feat, and all stats have decreased by 2 as a result.";
-					StatChange "Strength" by -2;
-					StatChange "Dexterity" by -2;
-					StatChange "Stamina" by -2;
-					StatChange "Charisma" by -2;
-					StatChange "Intelligence" by -2;
-					StatChange "Perception" by -2;
+					StatChange "Strength" by -2 silently;
+					StatChange "Dexterity" by -2 silently;
+					StatChange "Stamina" by -2 silently;
+					StatChange "Charisma" by -2 silently;
+					StatChange "Intelligence" by -2 silently;
+					StatChange "Perception" by -2 silently;
 				if TerminatorSleepActivated is false:
 					now TerminatorSleepActivated is True;
 					decrease score by 100;

--- a/Core Mechanics/Sleeptimer.i7x
+++ b/Core Mechanics/Sleeptimer.i7x
@@ -12,12 +12,12 @@ an everyturn rule:
 			if WellRestedTimer <= 0:
 				FeatLoss "Well Rested";
 				say "     It has been a while since you last rested and any benefit you gained from it is now gone. You have lost the 'Well Rested' Feat, and all stats have decreased by 2 as a result.";
-				StatChange "Strength" by -2;
-				StatChange "Dexterity" by -2;
-				StatChange "Stamina" by -2;
-				StatChange "Charisma" by -2;
-				StatChange "Intelligence" by -2;
-				StatChange "Perception" by -2;
+				StatChange "Strength" by -2 silently;
+				StatChange "Dexterity" by -2 silently;
+				StatChange "Stamina" by -2 silently;
+				StatChange "Charisma" by -2 silently;
+				StatChange "Intelligence" by -2 silently;
+				StatChange "Perception" by -2 silently;
 			else:
 				decrease WellRestedTimer by 1;
 		else: [Not slept recently, getting tired.]

--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -4692,12 +4692,12 @@ to Rest:
 			if "Well Rested" is not listed in feats of Player:
 				FeatGain "Well Rested";
 				say "     Well Rested - All stats increased by 2!";
-				StatChange "Strength" by 2;
-				StatChange "Dexterity" by 2;
-				StatChange "Stamina" by 2;
-				StatChange "Charisma" by 2;
-				StatChange "Intelligence" by 2;
-				StatChange "Perception" by 2;
+				StatChange "Strength" by 2 silently;
+				StatChange "Dexterity" by 2 silently;
+				StatChange "Stamina" by 2 silently;
+				StatChange "Charisma" by 2 silently;
+				StatChange "Intelligence" by 2 silently;
+				StatChange "Perception" by 2 silently;
 			now WellRestedTimer is 6;
 
 carry out resting:

--- a/UrsaOmega/Campus Gym.i7x
+++ b/UrsaOmega/Campus Gym.i7x
@@ -217,7 +217,7 @@ to say statraining:
 	decrease freecred by workoutprice;
 	if stamina of Player < 18:
 		say "     Your legs feel like rubber and you gulp down every breath of air like it's your last, but you feel like you'll be able to run just a little bit further next time thanks to your training.";
-		StatChange "Stramina" by 1;
+		StatChange "Stamina" by 1;
 		increase workoutprice by 35;
 		follow the turnpass rule;
 	else:


### PR DESCRIPTION
### Purpose of the PR
Fixed two issues `EJSteff#7308`  mentioned [here](https://discordapp.com/channels/333559467218173953/344610529223901184/609498393043009536) and [here](https://discordapp.com/channels/333559467218173953/606849270007726113/609238096394977310).

### GamePlay changes
- **Randy:** Stamina training with Randy now properly raises your stamina again.
- **Well Rested:** Now changes your 6 stats without printing every single stat gain or loss.

### Internal changes
- You may now silence the output of `StatChange` by prefixing it with `silently`. Example:
  ```inform7
  StatChange "Strength" by 2 silently;
  ```
- If an invalid stat is used in `StatChange` it now prints an error message to the player.