### PR TITLE
Fix peacock description and some gender trouble

### DIFF
--- a/Core Mechanics/Sex and Infection Functions.i7x
+++ b/Core Mechanics/Sex and Infection Functions.i7x
@@ -28,6 +28,34 @@ to decide which text is GetSpeciesName from (N - a text):
 			decide on N;
 	decide on ""; [Name not found or N is empty - Return "" as a failsafe]
 
+to RemoveManhoodFrom ( x - a person ):
+	now Cock Count of x is 0;
+	now Cock Length of x is 0;
+	now Ball Size of x is 0;
+
+to RemoveWomanhoodFrom ( x - a person ):
+	now Cunt Count of x is 0;
+	now Cunt Depth of x is 0;
+	now Cunt Tightness of x is 0;
+
+[compares genitals and returns a number for the result]
+[ > 0 - x is either a pure male or a herm and the cock is longer ]
+[ = 0 - x is either a neuter or a herm and cock length and cunt depth are the same ]
+[ < 0 - x is either a pure female or a herm and the cunt is deeper ]
+to decide which number is CompareGenitals of ( x - a person ):
+	if x is puremale, decide on Cock Length of x;
+	if x is neuter, decide on 0;
+	if x is purefemale, decide on 0 - Cunt Depth of x;
+	[x is a herm:]
+	decide on Cock Length of x - Cunt Depth of x;
+
+[
+[ Example for later use. e. g.: if GetBallSize of Player > 4: ]
+to decide which number is GetBallSize of ( x - a person ):
+	if x is male, decide on Ball Size of x;
+	decide on 0;
+]
+
 to SetInfectionsOf ( Target - a person ) to infections of ( Source - a person):
 	if Source is Player and Player is not FullyNewTypeInfected:
 		now HeadName of Target is FaceName of Source;

--- a/Guest Writers/Butterfly.i7x
+++ b/Guest Writers/Butterfly.i7x
@@ -285,9 +285,7 @@ To say butterfly attack:
 				say " Strange [one of]erotic tingles[or]cold waves[or]hot flashes[at random] run over your [if Cock Count of Player > 1][one of]cocks[or]lengths[or]shafts[or]poles[at random] as they begin to shrink. They dwindle[else][one of]cock[or]man meat[or]shaft[or]pole[at random] as it begins to shrink. It dwindles[end if] in size, becoming [descr]. ";
 				if Cock Length of Player < 1 or Ball Size of Player < 1:
 					say "You barely have time to give a whimper as you cease to be a male.";
-					now Cock Count of Player is 0;
-					now Cock Length of Player is 0;
-					now Ball Size of Player is 0;
+					RemoveManhoodFrom Player;
 				if Cock Count of Player > 1 and a random chance of 1 in 3 succeeds:
 					say "Sudden pleasure runs through one of your doomed [Cock of Player] cocks as it sprays the last of its seed, dwindling down to nothing at all and vanishing, leaving only the powerful orgasm to remember it by.";
 					decrease Cock Count of Player by 1;
@@ -305,7 +303,7 @@ To say butterfly attack:
 				say " Strange [one of]erotic tingles[or]cold waves[or]hot flashes[at random] run over your [if Cunt Count of Player > 1][one of]cunts[or]pussies[or]vaginas[or]clefts[at random] as they begin to shrink. They[else][one of]cunt[or]pussy[or]vagina[or]cleft[at random] as it begins to shrink. It[end if] dwindles in size, becoming [descr]. ";
 				if Cunt Depth of Player < 1 or Cunt Tightness of Player < 1:
 					say "With a sickening noise, you cease to be female all together.";
-					now Cunt Count of Player is 0;
+					RemoveWomanhoodFrom Player;
 				if Cunt Count of Player > 1 and a random chance of 1 in 3 succeeds:
 					say "An odd wet noise has you peeking in time to see one of your [one of]cunts[or]pussies[at random] have vanished!";
 					decrease Cunt Count of Player by 1;

--- a/Guest Writers/Male Peacock.i7x
+++ b/Guest Writers/Male Peacock.i7x
@@ -22,19 +22,19 @@ to say peacockdesc:
 	now peacockcontrol is 0;
 
 to say peacockskin:
-	if Cock Length of Player > Cunt Depth of Player:
+	if CompareGenitals of Player > 0:
 		say "blue and green feathers covering your";
 	else:
 		say "brown-hued feathers covering your";
 
 to say peacocktail:
-	if Cock Length of Player > Cunt Depth of Player:
+	if CompareGenitals of Player > 0:
 		say "You have a beautiful fan of feathers for a tail. The feathers are decorated with hypnotic eyes";
 	else:
 		say "A feathered tail decorates your rear, like half of a long skirt";
 
 to say peacockasschange:
-	if Cock Length of Player > Cunt Depth of Player:
+	if CompareGenitals of Player > 0:
 		say "feathers emerge from it. They form a peacock tail that you are able to fan with ease";
 	else:
 		say "brown feathers emerge from it. They form a tail that comes down to your knees";
@@ -103,7 +103,7 @@ When Play begins:
 	now defeated entry is "The last hit knocks the blue bird on the ground. He stands up quickly and flees in a panic, his pride completely shattered."; [ Text or say command used when Monster is defeated.]
 	now victory entry is "[peacockvictory]";
 	now desc entry is "[peacockdesc]";
-	now face entry is "bird-like head. You pass quite a bit of your time admiring your"; [ Face description, format as "Your face is (your text)."]
+	now face entry is "bird-like. You pass quite a bit of your time admiring it"; [ Face description, format as "Your face is (your text)."]
 	now body entry is "tall and slender; your legs are double-jointed and bird-like, while your arms have been mutated into feathered wings, ending with five extra-thick feathers, flexible and mobile as fingers"; [ Body Description, format as "Your Body is (your text)"]
 	now skin entry is "[peacockskin]"; [ skin Description, format as "You have (your text) skin"]
 	now tail entry is "[peacocktail]."; [ Tail description, write a whole Sentence or leave blank. ]
@@ -349,7 +349,7 @@ Section 6 - Endings
 when play ends:
 	if BodyName of Player is "Peacock":
 		if humanity of Player < 10:
-			if Cock Length of Player > Cunt Depth of Player:
+			if CompareGenitals of Player > 0:
 				say "You decide to remain in the quarantined city. With your wits and abilities, you will surely find many different... ahem... [']fruits['] to taste.";
 			else:
 				say "You decide to remain in the quarantined city. You become the mate of a male peacock, or rather, his favorite mate. Neither of you wants to sacrifice his fun, after all...";

--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -3539,9 +3539,7 @@ This is the sex change rule:
 			say "Strange [one of]erotic tingles[or]cold waves[or]hot flashes[at random] run over your [if Cock Count of Player > 1][one of]cocks[or]penises[or]shafts[or]poles[at random] as they begin[else][one of]cock[or]man meat[or]shaft[or]pole[at random] as it begins[end if] to shrink. [if Cock Count of Player > 1]They dwindle[else]It dwindles[end if] in size, becoming [descr] while[if Player is internal] you imagine[end if] your [one of]balls[or]testicles[or]nuts[or]gonads[at random] become [Ball Size Adjective of Player]. ";
 			if Cock Length of Player < 1 or Ball Size of Player < 1:
 				say "You barely have time to give a whimper as you cease to be a male.";
-				now Cock Count of Player is 0;
-				now Cock Length of Player is 0;
-				now Ball Size of Player is 0;
+				RemoveManhoodFrom Player;
 			else:
 				say "[line break]";
 		if Cock Count of Player > 1 and a random chance of 2 in 5 succeeds and "All The Things" is not listed in feats of Player:
@@ -3630,7 +3628,7 @@ This is the sex change rule:
 			say "Strange [one of]erotic tingles[or]cold waves[or]hot flashes[at random] run over your [if Cunt Count of Player > 1][one of]cunts[or]pussies[or]vaginas[or]clefts[at random] as they begin to shrink. They dwindle[else][one of]cunt[or]pussy[or]vagina[or]cleft[at random] as it begins to shrink. It dwindles[end if] in size, becoming [descr]. ";
 			if Cunt Depth of Player < 1 or Cunt Tightness of Player < 1:
 				say "With a sickening noise, you cease to be female all together.";
-				now Cunt Count of Player is 0;
+				RemoveWomanhoodFrom Player;
 			else:
 				say "[line break]";
 		if Cunt Count of Player > 1 and a random chance of 2 in 5 succeeds and "All The Things" is not listed in feats of Player:
@@ -3773,9 +3771,7 @@ to grow cock by (x - a number):
 		continue the action;
 	else if "Single Sexed" is listed in feats of Player and player is female:
 		say "Strange [one of]erotic tingles[or]cold waves[or]hot flashes[at random] run over your [one of]cunt[sfn][or]puss[yfn][or]vagina[sfn][or]cleft[sfn][at random] as [ittheyf] begin[sfv] to shrink. [ItTheyf] dwindle[sfv] in size before vanishing with a sickening noise as you cease to be female all together.";
-		now Cunt Count of Player is 0;
-		now Cunt Depth of Player is 0;
-		now Cunt Tightness of Player is 0;
+		RemoveWomanhoodFrom Player;
 	let prevcock be Cock Length of Player;
 	increase Cock Length of Player by a random number from 1 to x;
 	if "Modest Organs" is listed in feats of Player and Cock Length of Player > 8:
@@ -7182,29 +7178,25 @@ To startgenderlockshift:
 			now Cock Length of Player is 6;
 			now the Ball Size of the player is 3;
 			now Breast Size of Player is 0;
-			now Cunt Count of Player is 0;
-			now Cunt Depth of Player is 0;
+			RemoveWomanhoodFrom Player;
 		-- 4:		[female]
 			now Cunt Count of Player is 1;
 			now Cunt Depth of Player is 6;
 			now Cunt Tightness of Player is 4;
 			now Breast Size of Player is 2;
-			now Cock Count of Player is 0;
-			now Cock Length of Player is 0;
+			RemoveManhoodFrom Player;
 		-- 5:		[shemale]
 			now Cock Count of Player is 1;
 			now Cock Length of Player is 6;
 			now the Ball Size of the player is 3;
 			now Breast Size of Player is 2;
-			now Cunt Count of Player is 0;
-			now Cunt Depth of Player is 0;
+			RemoveWomanhoodFrom Player;
 		-- 6: [cuntboy]
 			now Cunt Count of Player is 1;
 			now Cunt Depth of Player is 6;
 			now Cunt Tightness of Player is 4;
 			now Breast Size of Player is 0;
-			now Cock Count of Player is 0;
-			now Cock Length of Player is 0;
+			RemoveManhoodFrom Player; [balls not included ;-)]
 		-- 7: [male herm]
 			now Cock Count of Player is 1;
 			now Cock Length of Player is 6;

--- a/WRITING GUIDE.md
+++ b/WRITING GUIDE.md
@@ -263,7 +263,7 @@ Breast Size of Amy is 2. [B cup at the start]
 This will allow you to make use of these values in scenes, and be quite useful if you have a NPC that might gender shift or the like.
 An example:
 ```
-if cock length of player > cunt length of Amy + 2: [some stretching allowed]
+if Cock Length of Player > Cunt Depth of Amy + 2: [some stretching allowed]
 	say "     The female husky wines a little as you bottom out inside her before your cock is all the way in. 'Not so deep please, you're too big.' [...]'";
 else if cock length of player < cunt length of Amy - 3: [a bit small, eh?]
 	say "     The female husky gives a needy whine and asks, 'Are you, ehm... already in?'";

--- a/Wahn/Body Shop.i7x
+++ b/Wahn/Body Shop.i7x
@@ -326,14 +326,12 @@ to say MoreauDickSale:
 			say "     The mannequin pulls the curtain closed and waits for you to present your body to it, stripping off any clothing that might get in the way. Meanwhile, the creature gives what you can only describe as a hungry stare. Then it steps forward and lays a hand on your chest, stroking it down your front almost sexually before it comes to cup your genitals. It is a touches you - a cool sensation to feel it against you, breaking the illusion a bit of it being a living thing. Something seems to tug at your self, drawing essence away from your body, and with an odd fascination, you glance down between your bodies, seeing its own crotch taking on a shape very much like your own.";
 			setmonster "Mannequin";
 			choose row MonsterID from the Table of Random Critters;
-			if Cock Count of Player > 1:
+			if Cock Count of Player > 0:
 				say "     Sudden pleasure runs through your doomed [Cock of Player] cock[smn] as [ittheym] spray[smv] the last of [itstheirm] seed, dwindling down to nothing at all and vanishing, leaving only [one of]the powerful[or]that final[at random] orgasm to remember [itthemm] by as you cease to be a male altogether.";
-			if Cunt Count of Player > 1:
+			if Cunt Count of Player > 0:
 				say "     An odd, wet noise has you peeking in time to see your [one of]cunt[sfn][or]puss[yfn][at random] vanish! With a strange slurp of closing flesh, you cease to be female altogether.";
-			now Cock Count of Player is 0;
-			now Cock Length of Player is 0;
-			now Ball Size of Player is 0;
-			now Cunt Count of Player is 0;
+			RemoveManhoodFrom Player;
+			RemoveWomanhoodFrom Player;
 			now CockName of Player is Name entry;
 			now Cock of Player is cock entry;
 			if "Body Shop Guarantee - Crotch" is listed in feats of Player:


### PR DESCRIPTION
### Purpose of this PR
Fix peacock face desc and a couple gender issues, e. g. pure females with balls or males with no cunts but a cunt depth.

### Gameplay changes
- **Peacock**: Fixed the face description.
- **Peacock**: Pure male peacocks shouldn't show up in female colors anymore.
- **Gender switching**: If you cease to be a male or a female all corresponding crotch sizes are nor properly set to 0.

### Internal changes
Added the following functions to `Sex and Infection Functions.i7x`:

- ```inform7
  to RemoveManhoodFrom ( x - a person ):
  ```
  Sets all cock and ball values to 0.

- ```inform7
  to RemoveWomanhoodFrom ( x - a person ):
  ```
  Sets all cunt values to 0.

- ```inform7
  to decide which number is CompareGenitals of ( x - a person ):
  ```

  Compares genitals and returns a number for the result:
  - \> 0 → x is either a pure male or a herm and the cock is longer
  - = 0 → x is either a neuter or a herm and cock length and cunt depth are the same
  - \< 0 → x is either a pure female or a herm and the cunt is deeper

- Example:
  
  ```inform7
  if CompareGenitals of Player > 0:
	say "Your cock is longer than your cunt is deep or you have no cunt at all!";

  if CompareGenitals of Player >= 2:
	say "Your cock is at least 2 sizes longer than your cunt is deep or you have no cunt at all!";
  ```

### Notes
**Important: This concentrates on fixing the 'Gameplay issues' listed above!**

When Coalsack reported issues with the peacock form [here](https://discordapp.com/channels/333559467218173953/606849270007726113/612722422977789991) I've discovered yet another gender issue: Pure male characters would still have a `Cunt Depth` since it wasn't automatically set to 0, when starting as a male or when the player 'ceases to be a male'. To fix that I've added the above functions and implemented them in a few locations.

As an example for future uses I've added the following, currently commented out function:

```inform7
to decide which number is GetBallSize of ( x - a person ):
```
This would only return a ballsize above 0, if the 'person' actually is a male aka has a cock. The code is full of `if Ball Size of Player > x` and I'm not in the mood of replacing them all with `if GetBallSize of Player > x` right now. Especially because that would cause a huge diff.

This could be extended with functions, like

```inform7
to decide which number is GetCuntDepth of ( x - a person ):
```
and so on later. Think of it as a suggestion.

