### PR TITLE
Fixing room connections

### DIFF
--- a/Rikaeus/Azrael.i7x
+++ b/Rikaeus/Azrael.i7x
@@ -25,6 +25,14 @@ EnrollmentTokens is a number that varies.
 AzraelRelationship is a number that varies.
 ClassPaymentAccepted is a truth state that varies.
 
+AzraelRoomConnection is a number that varies.[@Tag:NotSaved]
+
+an everyturn rule: [bugfixing rules for players that import savegames]
+	if AzraelRelationship is 2 and AzraelRoomConnection is 0: [event resolved the right way, room not connected yet]
+		change northwest exit of Second Floor Male Dorms to Your Dorm Room;
+		change southeast exit of Your Dorm Room to Second Floor Male Dorms;
+		now AzraelRoomConnection is 1; [make sure that it connects the room only once]
+
 Section 1 - Introduction Event
 
 instead of going up from College Administration Building while AzraelRelationship is 0:

--- a/Rikaeus/Jake.i7x
+++ b/Rikaeus/Jake.i7x
@@ -22,6 +22,14 @@ The sarea of Panda Inspiration is "Campus".
 when play begins:
 	add Panda Inspiration to BadSpots of MaleList;
 
+JakeRoomConnection is a number that varies.[@Tag:NotSaved]
+
+an everyturn rule: [bugfixing rules for players that import savegames]
+	if HP of Jake is 4 and JakeRoomConnection is 0: [event resolved the right way, room not connected yet]
+		change east exit of Second Floor Male Dorms to Jake's Room;
+		change west exit of Jake's Room to Second Floor Male Dorms;
+		now JakeRoomConnection is 1; [make sure that it connects the room only once]
+
 instead of going to Tenvale College Male Dorms while (Panda Inspiration is not resolved and LastCampusWalkin - turns > 0 and HP of Jake is 0 and a random chance of 1 in 3 succeeds):
 	move player to Tenvale College Male Dorms;
 	FirstJakeEvent;

--- a/Rikaeus/Randall and Brad.i7x
+++ b/Rikaeus/Randall and Brad.i7x
@@ -30,6 +30,14 @@ when play begins:
 	add Hanging out on the Green to BadSpots of MaleList;
 	add Hanging out on the Green to BadSpots of FurryList;
 
+RandallBradRoomConnection is a number that varies.[@Tag:NotSaved]
+
+an everyturn rule: [bugfixing rules for players that import savegames]
+	if New Roommates is resolved and RandallBradRoomConnection is 0: [event resolved the right way, room not connected yet]
+		change southwest exit of Tenvale College Male Dorms to Randall's Room;
+		change northeast exit of Randall's Room to Tenvale College Male Dorms;
+		now RandallBradRoomConnection is 1; [make sure that it connects the room only once]
+
 instead of going to College Walkway West while (Hanging out on the Green is active and Hanging out on the Green is not resolved and LastCampusWalkin - turns > 0 and StewartRelationship > 0 and RandallBradRelationship < 1 and a random chance of 1 in 3 succeeds):
 	move player to College Walkway West;
 	FirstRandallEvent;

--- a/Rikaeus/Stewart.i7x
+++ b/Rikaeus/Stewart.i7x
@@ -17,6 +17,18 @@ StewartRelationship is a number that varies.
 CloudKnowledge is a number that varies.
 StewartLocationCounter is a number that varies.
 
+BelltowerCloudsRoomConnection is a number that varies.[@Tag:NotSaved]
+StewardRoomConnection is a number that varies.[@Tag:NotSaved]
+
+an everyturn rule: [bugfixing rules for players that import savegames]
+	if CloudKnowledge > 0 and BelltowerCloudsRoomConnection is 0: [event resolved the right way, room not connected yet]
+		change up exit of College Belltower to The Clouds;
+		now BelltowerCloudsRoomConnection is 1; [make sure that it connects the room only once]
+	if StewartRelationship is 2 and StewardRoomConnection is 0: [event resolved the right way, room not connected yet]
+		change south exit of Tenvale College Male Dorms to Stewart's Room;
+		change north exit of Stewart's Room to Tenvale College Male Dorms;
+		now StewardRoomConnection is 1; [make sure that it connects the room only once]
+
 [Room Declaration]
 
 Table of GameRoomIDs (continued)

--- a/Rikaeus/Wally.i7x
+++ b/Rikaeus/Wally.i7x
@@ -32,6 +32,14 @@ WallyOrcFled is a number that varies.
 InsightGained is a number that varies.
 WallyTrust is a number that varies.
 
+WallyRoomConnection is a number that varies.[@Tag:NotSaved]
+
+an everyturn rule: [bugfixing rules for players that import savegames]
+	if HP of Wally is 3 and WallyRoomConnection is 0: [event resolved the right way, room not connected yet]
+		change southwest exit of Second Floor Male Dorms to Wally's Room;
+		change east exit of Wally's Room to Second Floor Male Dorms;
+		now WallyRoomConnection is 1; [make sure that it connects the room only once]
+
 Table of GameEventIDs (continued)
 Object	Name
 College Hopeful	"College Hopeful"

--- a/Rikaeus/Wally.i7x
+++ b/Rikaeus/Wally.i7x
@@ -193,6 +193,7 @@ to ThirdWallyEvent:
 	say "     Eagerly the otter grabs a pen and starts writing in the needed information for the papers. It takes not a few minutes for him to finish completing it and when he does the Dean nods and takes the documents and files them away. He then hands Wally a key before speaking to him. 'Your room is the southwest one on the second floor of the male doors and your classes start tomorrow,' the Angel explains to him before smiling softly at you guys. 'Enjoy your stay at Tenvale College,' the Dean says, causing the otter to nod happily. The two of you stand up and head out of the room. As you move out of the area, he turns towards you. 'I'm going to head to my new room and get settled in, you can visit me there whenever you want!' Wally says with an excited voice. You agree and say that you'll let him get to it as you head off on your own and he goes towards the dorms.";
 	now HP of Wally is 3;
 	move Wally to Wally's Room;
+	now Otter Class Sign Up is resolved;
 	change southwest exit of Second Floor Male Dorms to Wally's Room;
 	change east exit of Wally's Room to Second Floor Male Dorms;
 

--- a/Speedlover/Kyrverth.i7x
+++ b/Speedlover/Kyrverth.i7x
@@ -37,7 +37,7 @@ an everyturn rule: [bugfixing rules for players that import savegames]
 		now Jewel Heist is active;
 	if Resolution of Strange Sighting is 0 and Strange Sighting is active:
 		now Strange Sighting is not resolved;
-	if Strange Sighting is resolved and Resolution of Strange Sighting is 1 and KyrverthRoomConnection is 0: [event resolved the right way, room not connected yet]
+	if Strange Sighting is resolved and Resolution of Strange Sighting is 2 and KyrverthRoomConnection is 0: [event resolved the right way, room not connected yet]
 		change the South exit of Overgrown Street to Dragons Den;
 		change the North exit of Dragons Den to Overgrown Street;
 		now KyrverthRoomConnection is 1; [make sure that it connects the room only once]

--- a/UrsaOmega/Campus Gym.i7x
+++ b/UrsaOmega/Campus Gym.i7x
@@ -11,6 +11,14 @@ Campus Gym by UrsaOmega begins here.
 
 ]
 
+CampusGymConnection is a number that varies.[@Tag:NotSaved]
+
+an everyturn rule: [bugfixing rules for players that import savegames]
+	if Working Out is resolved and CampusGymConnection is 0: [event resolved the right way, room not connected yet]
+		change southwest exit of Athletic Street to Campus Gym;
+		change northeast exit of Campus Gym to Athletic Street;
+		now CampusGymConnection is 1; [make sure that it connects the room only once]
+
 Section 1 - Finding the gym
 
 Table of GameEventIDs (continued)

--- a/Wahn/Eric.i7x
+++ b/Wahn/Eric.i7x
@@ -136,6 +136,14 @@ ConfSvenEricInteraction is a number that varies.
 lastConfSvenEricInteraction is a number that varies.
 lastRaneEricInteraction is a number that varies.
 
+LockerroomRoomConnection is a number that varies.[@Tag:NotSaved]
+
+an everyturn rule: [bugfixing rules for players that import savegames]
+	if Barricaded Lockerroom is resolved and Resolution of Barricaded Lockerroom is 1 and LockerroomRoomConnection is 0: [event resolved the right way, room not connected yet]
+		change southeast exit of Athletic Street to Sports Arena Lockerroom;
+		change northwest exit of Sports Arena Lockerroom to Athletic Street;
+		now LockerroomRoomConnection is 1; [make sure that it connects the room only once]
+
 Section 1 - Meeting Event
 
 Table of GameEventIDs (continued)

--- a/Wahn/Orc Female.i7x
+++ b/Wahn/Orc Female.i7x
@@ -784,7 +784,7 @@ to say KatyaFriendshipPath:
 			now HP of Katya is 2; [third visit completed successfully]
 		else:
 			LineBreak;
-			say "     The reply Katya gives you < encouraging. 'Fuck off. Stop bothering me,' she says, then waves vaguely into the wide open plain and adds, 'Go find your own place to hang out at - or be eaten by something. What do I care?!' With that said, the orc steps back into the crumbling walls of her camp, pulling the tarp closed behind her. Hm, seems like your attempt to chat her up let something to be desired. You won't get any further with her today, so there is nothing left but to shrug and wander away...";
+			say "     The reply Katya gives you is not very encouraging. 'Fuck off. Stop bothering me,' she says, then waves vaguely into the wide open plain and adds, 'Go find your own place to hang out at - or be eaten by something. What do I care?!' With that said, the orc steps back into the crumbling walls of her camp, pulling the tarp closed behind her. Hmm, seems like your attempt to chat her up left something to be desired. You won't get any further with her today, so there is nothing left but to shrug and wander away...";
 			wait for any key;
 			move player to Dry Plains;
 	else if HP of Katya is 2: [fourth visit]

--- a/Wahn/Satyr Frat.i7x
+++ b/Wahn/Satyr Frat.i7x
@@ -28,12 +28,17 @@ SatyrFratPartyStage is a number that varies.
 SatyrFratRichardRelationship is a number that varies.
 SatyressStage is a number that varies.
 SatyrFratRoomConnection is a number that varies.[@Tag:NotSaved]
+RichardRoomConnection is a number that varies.[@Tag:NotSaved]
 
 an everyturn rule:
 	if SatyrFratPartyStage > 0 and SatyrFratPartyStage < 99 and SatyrFratRoomConnection is 0:
 		change the south exit of Greek Street to Satyr Frat Dummy Room;
 		change the north exit of Satyr Frat Dummy Room to Greek Street;
 		now SatyrFratRoomConnection is 1; [room connected]
+	if SatyrFratRichardRelationship is 4 and RichardRoomConnection is 0:
+		change the east exit of Tenvale College Dorms to Richard's Room; [connecting the location to the travel room]
+		change the west exit of Richard's Room to Tenvale College Dorms; [connecting the location to the travel room]
+		now RichardRoomConnection is 1; [room connected]
 
 to say Satyr Frat Party:
 	now battleground is "void";


### PR DESCRIPTION
### Purpose of the PR
Bug fixing only. Mainly for imported games.

### Gameplay changes
- **Import**: Fixed several room connections getting lost after import
- **Kyrverth**: Due to a typo his den disappeared after an import or appeared when it shouldn't actually exist.
- **Katya**: Fixed a couple typos.
- **Wally**: No more repeated Otter Class Sign Up.

### Internal changes
Only 'visible' aka gameplay changes here.

### Notes
About the fix for Kyrverth: I've stumbled over that oversight while skimming though the room connection fixes and looking at the code before and after the fix it *should* do, whats intended without going into the tedious export progress → compile → import progress to test, if everything works nice and smoothly.

As for the room fixes: I've verified that the Campus Gym room connection survives an import now and that I've tested Wally before and after the fix.

As for the other fixes: Looking at the code and the diffs: They compile without errors and should work as intended though I haven't tested them. Especially, because the Inform 7 IDE doesn't have a 'restart after a crash without compiling again' button ... and because I can't use old saves ...

**TL;DR**: It would be neat, if someone else could look over the PR before merging :-)