### PR TITLE
Gryphons Plot code cleanup and other small fixes

### DIFF
--- a/Closerhenry/Campus Couple NPC.i7x
+++ b/Closerhenry/Campus Couple NPC.i7x
@@ -32,6 +32,10 @@ The description of Jadako's Room is "[jadakoroomdesc]".
 To say jadakoroomdesc:
 	say "     Jadako's room is a standard college dorm room. It's got different video game and anime posters hanging throughout, most depicting buff male characters. A television sits on a table with a collection of different DVDs, all of some anime or movie. A large, open glass window is on the other end of the room. Atop its windowsill is a collection of exotic sex toys, all proudly on display. The sheets to Jadako's bed are thrown about, suggesting he doesn't do a great job of staying tidy.";
 
+to connect Jadako's Room:
+	change the south exit of Jadako's Room to Tenvale College Male Dorms;
+	change the north exit of Tenvale College Male Dorms to Jadako's Room;
+
 Section 2 - Declaring Jadako and Joseph
 
 Table of GameCharacterIDs (continued)

--- a/Closerhenry/Campus Lovers.i7x
+++ b/Closerhenry/Campus Lovers.i7x
@@ -9,13 +9,10 @@ Version 2 of Campus Lovers by Closerhenry begins here.
 CampusLoversTrackingVariable is a number that varies.
 CampusLoversProgressTurn is a number that varies.
 CampusCoupleRelationship is a number that varies.
-JadakoRoomConnection is a number that varies.[@Tag:NotSaved]
 
-an everyturn rule:
-	if CampusCoupleRelationship is 1 and JadakoRoomConnection is 0: [event resolved the right way, room not connected yet]
-		change the south exit of Jadako's Room to Tenvale College Male Dorms;
-		change the north exit of Tenvale College Male Dorms to Jadako's Room;
-		now JadakoRoomConnection is 1; [make sure that it connects the room only once]
+a postimport rule: [bugfixing rules for players that import savegames]
+	if CampusCoupleRelationship is 1: [event resolved the right way, room not connected yet]
+		connect Jadako's Room;
 
 Table of GameEventIDs (continued)
 Object	Name
@@ -111,8 +108,7 @@ to CampusLoversEvent:
 			now CampusCoupleRelationship is 1;
 			move Joseph to Jadako's Room;
 			move Jadako to Jadako's Room;
-			change the south exit of Jadako's Room to Tenvale College Male Dorms;
-			change the north exit of Tenvale College Male Dorms to Jadako's Room;
+			connect Jadako's Room;
 		else:
 			LineBreak;
 			say "     As hot as this is, you don't really have time to watch the two fuck. You take care to break away without causing too much noise. As you leave, you hear the two moaning loudly. At least they are having a good time...";
@@ -121,8 +117,7 @@ to CampusLoversEvent:
 			now CampusCoupleRelationship is 1;
 			move Joseph to Jadako's Room;
 			move Jadako to Jadako's Room;
-			change the south exit of Jadako's Room to Tenvale College Male Dorms;
-			change the north exit of Tenvale College Male Dorms to Jadako's Room;
+			connect Jadako's Room;
 	now CampusLoversProgressTurn is turns; [saves the last turn in which their story progressed]
 
 

--- a/Core Mechanics/GameTables.i7x
+++ b/Core Mechanics/GameTables.i7x
@@ -1200,7 +1200,6 @@ Name(text)	Type(text)
 "ShadowBeastEventState"	"number"
 "shadowy"	"number"
 "SharkFountainCounter"	"number"
-"shiftable"	"number"
 "sierramem"	"number"
 "SilverToken"	"number"
 "sirenfight"	"number"

--- a/Core Mechanics/GameTables.i7x
+++ b/Core Mechanics/GameTables.i7x
@@ -568,7 +568,6 @@ Name(text)	Type(text)
 "GreenTumbTurn"	"number"
 "gryphoncomforted"	"number"
 "GryphonessKnowpreg"	"number"
-"GryphPlotTracking"	"number"
 "gsd_encounters"	"number"
 "gsd_pet"	"number"
 "gsd_var"	"number"

--- a/Core Mechanics/Story Skipper Loose Variables.i7x
+++ b/Core Mechanics/Story Skipper Loose Variables.i7x
@@ -2453,8 +2453,6 @@ to NumberVariableSave:
 			now NumberVarValue entry is shadowy;
 		-- "SharkFountainCounter":
 			now NumberVarValue entry is SharkFountainCounter;
-		-- "shiftable":
-			now NumberVarValue entry is shiftable;
 		-- "sierramem":
 			now NumberVarValue entry is sierramem;
 		-- "SilverToken":
@@ -6138,7 +6136,7 @@ to VariableNumberLoad:
 				-- "SharkFountainCounter":
 					now SharkFountainCounter is numberVarValue entry;
 				-- "shiftable":
-					now shiftable is numberVarValue entry;
+					now Resolution of Secure Area is numberVarValue entry;
 				-- "sierramem":
 					now sierramem is numberVarValue entry;
 				-- "SilverToken":

--- a/Core Mechanics/Story Skipper Loose Variables.i7x
+++ b/Core Mechanics/Story Skipper Loose Variables.i7x
@@ -1221,8 +1221,6 @@ to NumberVariableSave:
 			now NumberVarValue entry is gryphoncomforted;
 		-- "GryphonessKnowpreg":
 			now NumberVarValue entry is GryphonessKnowpreg;
-		-- "GryphPlotTracking":
-			now NumberVarValue entry is GryphPlotTracking;
 		-- "gsd_encounters":
 			now NumberVarValue entry is gsd_encounters;
 		-- "gsd_pet":
@@ -4909,8 +4907,6 @@ to VariableNumberLoad:
 					now gryphoncomforted is numberVarValue entry;
 				-- "GryphonessKnowpreg":
 					now GryphonessKnowpreg is numberVarValue entry;
-				-- "GryphPlotTracking":
-					now GryphPlotTracking is numberVarValue entry;
 				-- "gsd_encounters":
 					now gsd_encounters is numberVarValue entry;
 				-- "gsd_pet":

--- a/Core Mechanics/Story Skipper.i7x
+++ b/Core Mechanics/Story Skipper.i7x
@@ -1066,6 +1066,10 @@ to CharacterIconRestore:
 	JayIconRestore;
 	DrMattIconRestore;
 
+to RunPostImportRules:
+	say "Running Post Import Rules...";
+	follow the postimport rules;
+
 Section 2 - Trixie
 
 understand "export progress" as ProgressExport.
@@ -1120,6 +1124,7 @@ to say ProgressionImport:
 	NoteRestore;
 	VariableLoad;
 	CharacterIconRestore;
+	RunPostImportRules;
 
 Table of GameCharacterIDs (continued)
 object	name

--- a/Dys/Vent Fox.i7x
+++ b/Dys/Vent Fox.i7x
@@ -50,13 +50,9 @@ Version 2 of Vent Fox by Dys begins here.
 [   2 = Small                                                        ]
 [   3 = Average                                                      ]
 
-GarageRoomConnection is a number that varies.[@Tag:NotSaved]
-
-an everyturn rule:
-	if VentFoxContentLevel is 3 and GarageRoomConnection is 0:
-		change the North exit of Smith Haven Mall Lot West to Maintenance Garage;
-		change the South exit of Maintenance Garage to Smith Haven Mall Lot West;
-		now GarageRoomConnection is 1; [room connected]
+a postimport rule: [bugfixing rules for players that import savegames]
+	if VentFoxContentLevel is 3:
+		connect Maintenance Garage;
 
 Section 0 - Variables
 
@@ -232,6 +228,10 @@ The description of Maintenance Garage is "[MaintenanceGarageDescription]".
 
 to say MaintenanceGarageDescription:
 	say "     Vent's new home is sparsely decorated. A few workbenches line the rear wall, and a hydraulic lift is off to one side of the room. Aside from that, there's not much to see. Off to one corner, you can see Vent. He gives you a toothy grin as he sees you, eager to spend time with you.";
+
+to connect Maintenance Garage:
+	change the North exit of Smith Haven Mall Lot West to Maintenance Garage;
+	change the South exit of Maintenance Garage to Smith Haven Mall Lot West;
 
 Section 4 - Menus
 
@@ -748,8 +748,7 @@ to say VentFoxLastScavScene:
 	say "     Now that the guard has been dealt with, you and your friend continue your search for some easily accessible rubber. Looking around the lot, you eventually see a totaled truck. Upon closer examination, you notice there's a whole bed-full of tires in it! Vent seems to realize this too, as he hops up into the back of the truck, making quick work of the tires. Soon enough, he's devoured them all, and grown in size as well. Your foxy compatriot now stands taller than a horse when at full size. Of course, he doesn't stay that large for long, quickly shrinking back down to a much more manageable size, hopping out of the truck bed. With his hunger sated, the two of you make your way back to his hide out.";
 	now VentFoxContentLevel is 3;
 	now VentFoxLastFed is turns;
-	change the North exit of Smith Haven Mall Lot West to Maintenance Garage;
-	change the South exit of Maintenance Garage to Smith Haven Mall Lot West;
+	connect Maintenance Garage;
 
 Chapter 2 - Sex Scenes
 
@@ -1274,8 +1273,7 @@ Carry out MaxOutVentStats:
 	now VentFoxEncounterCount is 3;
 	now VentFoxContentLevel is 3;
 	now VentFoxRelationship is 3;
-	change the North exit of Smith Haven Mall Lot West to Maintenance Garage;
-	change the South exit of Maintenance Garage to Smith Haven Mall Lot West;
+	connect Maintenance Garage;
 
 ShowVentStats is an action applying to nothing.
 Understand "ventstats" as ShowVentStats.

--- a/Hellerhound/Qytat shifters.i7x
+++ b/Hellerhound/Qytat shifters.i7x
@@ -8,7 +8,7 @@ Shifting Room is a room. "[shiftingroom][line break]A room in a tent. The walls 
 It is private.
 It is fasttravel.
 
-a postimport rule:
+a postimport rule: [bugfixing rules for players that import savegames]
 	if Resolution of Secure Area > 0:
 		connect Shifting Room;
 

--- a/Hellerhound/Qytat shifters.i7x
+++ b/Hellerhound/Qytat shifters.i7x
@@ -8,16 +8,19 @@ Shifting Room is a room. "[shiftingroom][line break]A room in a tent. The walls 
 It is private.
 It is fasttravel.
 
-ShiftingRoomConnection is a number that varies.[@Tag:NotSaved]
+a postimport rule:
+	if Resolution of Secure Area > 0:
+		connect Shifting Room;
 
-an everyturn rule:
-	if shiftable is 1 and ShiftingRoomConnection is 0:
-		change the north exit of Qytat Plaza to Shifting Room;
-		now ShiftingRoomConnection is 1; [room connected]
+to connect Shifting Room:
+	change the north exit of Qytat Plaza to Shifting Room;
+	change the south exit of Shifting Room to Qytat Plaza;
+
 
 to say shiftingroom:
 	say "As you walk towards the tent to the north, you see a bunch of muddy footprints leading inside. You follow, but the mud seems to have been cleaned from in here, since the whole room is pristine. The acrid tang of nanites no longer permeates the air here, and the soft bluish glow warms you.";
-	now shiftable is 2;
+	connect Shifting Room;
+	now Resolution of Secure Area is 2;
 
 the scent of shifting room is "The scent in here is very strange and otherworldly, but also heavy with the many musky scents you've encountered in the city.".
 

--- a/Hellerhound/Shifting.i7x
+++ b/Hellerhound/Shifting.i7x
@@ -52,8 +52,8 @@ instead of resolving a Secure Area:
 							say "     The door creaks open, and you walk into the dimly lit area.";
 							say "     There are glyphs and writings covering the wall, and some show people in various states of infection. Looking closer, you notice that the writings seem to denote that the nanites can be controlled, but it doesn't show how. You will have to search elsewhere for more information.";
 							increase the score by 500;
-							now shiftable is 1;
 							now Secure Area is resolved;
+							connect Shifting Room;
 							now Resolution of Secure Area is 1; [shifting ability gained]
 						else:
 							say "     The door refuses to budge, and you go on your way, disappointed that you couldn't get any further.";
@@ -70,8 +70,6 @@ instead of resolving a Secure Area:
 
 Section 2 - Shifting
 
-shiftable is a number that varies.
-
 shifting is an action applying to one topic.
 understand the command "shift" as something new.
 understand "shift [text]" as shifting.
@@ -81,7 +79,7 @@ ttransform is a number that varies.
 tmonster is a number that varies.
 
 carry out shifting:
-	if shiftable is 0 or shiftable is 1:
+	if Resolution of Secure Area < 2:
 		say "You do not know how to do that!";
 		stop the action;
 	if the humanity of Player < 50:
@@ -198,7 +196,7 @@ To transform:
 		now Libido of Player is the libido entry;
 
 when play ends:
-	if shiftable is 2:
+	if Resolution of Secure Area is 2:
 		if the humanity of Player > 50:
 			say "Your knowledge of how to shift aids you when you decide to help the rescue, and as a reward for your help, the army decides to replace the nanites you had with a new kind that do not spread.";
 		else:

--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -4865,7 +4865,7 @@ This is the turnpass rule:
 			now z is z;
 		else:
 			now z is 1;
-		if BodyName of Player is "Human" or ( shiftable is 2 and humanity of Player > 49 ): [blocked for humans and active shifters]
+		if BodyName of Player is "Human" or ( Resolution of Secure Area is 2 and humanity of Player > 49 ): [blocked for humans and active shifters]
 			now z is 0;
 		if z is 1:
 			repeat with y running from 1 to number of filled rows in Table of Random Critters:

--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -4805,6 +4805,8 @@ balloversize is a number that varies.
 skipturnblocker is a number that varies.
 mpregcount is a number that varies.
 
+postimport rules is a rulebook.
+
 Everyturn rules is a rulebook.
 
 This is the turnpass rule:

--- a/Nuku Valente/Zephyr Inc.i7x
+++ b/Nuku Valente/Zephyr Inc.i7x
@@ -6,20 +6,10 @@ Version 2 of Zephyr Inc by Nuku Valente begins here.
 Section 1 - Zephyr Office
 
 This is the zephyrad rule:
-	say "     Playing around with your radio in an attempt to gain some information about what is going on, you find a channel that seems to have a cycling message. 'Good day to anyone listening. This is Zephyr Incorporated. We wanted to you know that even during this current crisis, our branch office in this fine city remains open. Coordinates follow.' After making a mental note of the description, you listen on to the rest of their recording. 'We here are Zephyr Inc are dedicated to the betterment of mankind through science. And of course we also want to help people outlast what is currently going on. Therefore we are going to award company credit - also known as freecred - to those who contribute to keeping the more aggressive infected in check. A number of ways of observation are in effect in the city, and you will be credited for every hostile you pacify. Swing on by and spend your freecred on useful survival gear. We look forward to meeting you shortly.'";
-	say "     The radio continues, 'Please be advised that your Zephyr local branch now stocks our newest technological advancement - the Zephyr Personal Communicator, featuring satellite navigation in a device that fits in your pockets! Never get lost again, with the ZPC. Available now at a limited time offer of only 350 freecred. Visit your Zephyr branch now for more information!'";
-[	WaitLineBreak;
-	say "There is a brief pause and then a three-tone chime. A new voice comes in. 'As an added announcement, a recent creature migration has taken place. The fact that this coincides with Zephyr's planned lupine relocation program is purely coincidental. We shall provide information on this occurrence, but take no responsibility for those inconvenienced by ferals moving into their new habitats. Details follow. Deet-deet-deet.'";
-	say "- Feral and Alpha Wolves successfully relocated to the Urban Forest.";
-	say "- Football Wolfman and Wrestling Wolf successfully relocated to the College Campus.";
-	say "- Other creatures having migrated to the Urban Forest include the following: Awesome Tree, City Sprite, Cougar, Dryad, Elf, Elk, Elven Hunter, and several varieties of Skunk.";
-	say "- As expected with the decrease in local wolves, the Ewe and Ram numbers have risen. Expect increased sightings.";
-	say "- Bunny Jock threat level reassessed to level 4.";
-	say "- Ebonflame Whelp threat level reassessed to level 2.";
-	say "- Panther Taur threat level reassessed to level 4.";
-	say "- Incubus and Succubus threat levels reassessed to level 8.";
-	say "- Wrestling Wolf threat level reassessed to level 15."; ]
-	now Zephyr Lobby is known;
+	if Zephyr Lobby is not known:
+		say "     Playing around with your radio in an attempt to gain some information about what is going on, you find a channel that seems to have a cycling message. 'Good day to anyone listening. This is Zephyr Incorporated. We wanted to you know that even during this current crisis, our branch office in this fine city remains open. Coordinates follow.' After making a mental note of the description, you listen on to the rest of their recording. 'We here are Zephyr Inc are dedicated to the betterment of mankind through science. And of course we also want to help people outlast what is currently going on. Therefore we are going to award company credit - also known as freecred - to those who contribute to keeping the more aggressive infected in check. A number of ways of observation are in effect in the city, and you will be credited for every hostile you pacify. Swing on by and spend your freecred on useful survival gear. We look forward to meeting you shortly.'";
+		say "     The radio continues, 'Please be advised that your Zephyr local branch now stocks our newest technological advancement - the Zephyr Personal Communicator, featuring satellite navigation in a device that fits in your pockets! Never get lost again, with the ZPC. Available now at a limited time offer of only 350 freecred. Visit your Zephyr branch now for more information!'";
+		now Zephyr Lobby is known;
 
 Table of GameRoomIDs (continued)
 Object	Name

--- a/Rikaeus/Stewart.i7x
+++ b/Rikaeus/Stewart.i7x
@@ -17,17 +17,11 @@ StewartRelationship is a number that varies.
 CloudKnowledge is a number that varies.
 StewartLocationCounter is a number that varies.
 
-BelltowerCloudsRoomConnection is a number that varies.[@Tag:NotSaved]
-StewardRoomConnection is a number that varies.[@Tag:NotSaved]
-
-an everyturn rule: [bugfixing rules for players that import savegames]
-	if CloudKnowledge > 0 and BelltowerCloudsRoomConnection is 0: [event resolved the right way, room not connected yet]
-		change up exit of College Belltower to The Clouds;
-		now BelltowerCloudsRoomConnection is 1; [make sure that it connects the room only once]
-	if StewartRelationship is 2 and StewardRoomConnection is 0: [event resolved the right way, room not connected yet]
-		change south exit of Tenvale College Male Dorms to Stewart's Room;
-		change north exit of Stewart's Room to Tenvale College Male Dorms;
-		now StewardRoomConnection is 1; [make sure that it connects the room only once]
+a postimport rule: [bugfixing rules for players that import savegames]
+	if CloudKnowledge > 0: [event resolved the right way, room not connected yet]
+		connect The Clouds;
+	if StewartRelationship is 2: [event resolved the right way, room not connected yet]
+		connect Stewart's Room;
 
 [Room Declaration]
 
@@ -41,9 +35,12 @@ The description of The Clouds is "[CloudDesc]"
 to say CloudDesc:
 	say "     Taking a good look around, you notice that all you can really see is clouds for miles. However, it isn't completely empty. No, rather you see groups of flight-capable people hanging out up where you are. Most of them appear to be college students, which is to be expected as this area [italic type]is[roman type] above the belltower. Just like below, you also catch the occasional group having sex out in the open, something that draws your attention before you quickly look away.";
 
+to connect The Clouds:
+	change up exit of College Belltower to The Clouds;
+
 instead of going Northwest from College Walkway Northwest while CloudKnowledge is 0:
 	say "     When you walk forward and reach the belltower you notice a couple winged people taking flight from the ground. Upon closer examination you see that they appear to be flying up to the clouds. You realize that there must be something up there and wonder what you need to do to reach that location. Suddenly though a gryphon approaches you with a smile. 'Hey there, you look confused,' he says in a joyful tone. You give an assent to that statement and ask how to get up there. 'Well, you could just grow wings or perhaps you could find someone with them that could take you up there. I can't cause I'm in a hurry,' he says, apologizing before leaving. When he does you're left with your own thoughts on getting to the clouds.";
-	change up exit of College Belltower to The Clouds;
+	connect The Clouds;
 	now CloudKnowledge is 1;
 
 instead of going Up from College Belltower:
@@ -70,6 +67,10 @@ The description of Stewart's Room is "[StewartRoomDesc]"
 
 to say StewartRoomDesc:
 	say "     The first thing you notice about the harpy-boy's room are the bookshelves that line the walls to the brim. If you hadn't already studied with the guy, you'd think he was a book nut. Instead you know that he's just enthusiastic about his grades. Thankfully, at least for your horny mind, Stewart's bed isn't covered in literary tomes of knowledge. Otherwise that'd make it really difficult to have sex.";
+
+to connect Stewart's Room:
+	change south exit of Tenvale College Male Dorms to Stewart's Room;
+	change north exit of Stewart's Room to Tenvale College Male Dorms;
 
 instead of going south from Tenvale College Male Dorms while Stewart is not in Stewart's Room:
 	say "     Upon touching the door handle you notice it's locked, realizing that Stewart must not be in his room at the moment. You decide to try again later, hoping that he's going to be there.";
@@ -223,8 +224,7 @@ to say StewartStudying:
 				say "     Quite soon after that he grips your head tightly and begins to thrust furiously into your throat. When the sounds of balls slapping against your chin and a dick going in and out of your mouth fill the room you wonder why nobody has noticed you two. But you quickly realize that they probably have but just don't care. So, instead you relish the feeling of the delicious cock entering and leaving your gullet rapidly, moaning whenever you taste his precum. [if Player is not neuter]You begin to masturbate yourself rather determinedly, trying to reach your own orgasm, the gesture making you start to pant as well. [end if]However, soon Stewart's thrusts become much more frantic, which makes you realize that your sex partner is slowly reaching his peak, something that doesn't take too long to actually happen.";
 				say "     With a loud grunt, the harpy boy thrusts one last time before he starts spilling his copious load into your stomach. However, he has just enough cognitive functions to pull back and let the cum pool in your mouth. [if Player is not neuter]Just as your partner finishes, you reach your own orgasm, grunting out loud as you ride it out. [end if]While the two of you would probably love to enjoy your post-coital bliss, you are in a public place so you promptly clean up and slide back into the chair next to him. 'Ah-uh that was nice....' he trails off, blushing rather hard. 'Um, if you want to help me later or something, you can see me in my room, I'm only there late at night though,' Stewart says. You ask him which dorm room his is. 'Oh! My room is immediately south as soon as you enter the building,' he tells you before he quickly gets back to work, you standing up.";
 				now StewartRelationship is 2;
-				change south exit of Tenvale College Male Dorms to Stewart's Room;
-				change north exit of Stewart's Room to Tenvale College Male Dorms;
+				connect Stewart's Room;
 			else:
 				say "     Realizing that you don't have much knowledge on any of those subjects, you decide to ask Stewart for his notes. With a confused look on his face, he hands them over. The harpy boy quickly realizes what you're doing when you start spouting off different questions to him. With a determined look on his face, he begins to answer them with fervor. You do this for each and every subject, though it does get a little hilarious when you reach the anatomy book which seems to be updated with penises from different infections and you notice the cum stains. Stewart blushes and quickly says that you've helped him enough before grabbing the book from your hands. Seeing that you won't get any further with him, you get up from the chair and stand.";
 		else:

--- a/Rikaeus/Tenvale College Campus.i7x
+++ b/Rikaeus/Tenvale College Campus.i7x
@@ -216,6 +216,10 @@ The description of Wally's Room is "[wallysroomdesc]"
 to say wallysroomdesc:
 	say "     Taking a glance around the otter's room you notice it's not that very decorated, though to be honest it does make sense, since he is new to the campus. What it is decorated with is bits and bobs obviously from his previous home, a computer for school-work, a bookshelf, and a bed. Deciding to take a look at the items from his cave, you wander around, looking at them. Some of them are seashells that you assume he found while wandering the beach. Another one of the items is a photo of a young teen and his parents, something you assume to be a family picture for Wally. The last of the major items appears to be what's on your friends bed and he's sitting on. It's a large blue quilt that covers the entire thing, seemingly handmade. It intrigues you, as you wonder if the otter made it himself. Other than all that the room is rather bare";
 
+to connect Wally's Room:
+	change southwest exit of Second Floor Male Dorms to Wally's Room;
+	change east exit of Wally's Room to Second Floor Male Dorms;
+
 [Room Declaration]
 
 Table of GameRoomIDs (continued)

--- a/Rikaeus/Wally.i7x
+++ b/Rikaeus/Wally.i7x
@@ -32,13 +32,9 @@ WallyOrcFled is a number that varies.
 InsightGained is a number that varies.
 WallyTrust is a number that varies.
 
-WallyRoomConnection is a number that varies.[@Tag:NotSaved]
-
-an everyturn rule: [bugfixing rules for players that import savegames]
-	if HP of Wally is 3 and WallyRoomConnection is 0: [event resolved the right way, room not connected yet]
-		change southwest exit of Second Floor Male Dorms to Wally's Room;
-		change east exit of Wally's Room to Second Floor Male Dorms;
-		now WallyRoomConnection is 1; [make sure that it connects the room only once]
+a postimport rule: [bugfixing rules for players that import savegames]
+	if HP of Wally is 3: [event resolved the right way, room not connected yet]
+		connect Wally's Room;
 
 Table of GameEventIDs (continued)
 Object	Name
@@ -194,8 +190,7 @@ to ThirdWallyEvent:
 	now HP of Wally is 3;
 	move Wally to Wally's Room;
 	now Otter Class Sign Up is resolved;
-	change southwest exit of Second Floor Male Dorms to Wally's Room;
-	change east exit of Wally's Room to Second Floor Male Dorms;
+	connect Wally's Room;
 
 Table of GameCharacterIDs (continued)
 Object	Name

--- a/Shay/Gryphons Plot.i7x
+++ b/Shay/Gryphons Plot.i7x
@@ -3,7 +3,7 @@ Version 2 of Gryphons Plot by Shay begins here.
 [ Version 1 - Ideas for expansion by Wahn]
 [ Version 2 - Complete rewrite by Shay ]
 
-[ GryphPlotTracking                                                                                      ]
+[ Resolution of Gryphon's Plot                                                                           ]
 [   0: never ran into the event                                                                          ]
 [   1: had the event before, failed to find the fight                                                    ]
 [  10: player helped the soldiers                                                                        ]
@@ -12,7 +12,17 @@ Version 2 of Gryphons Plot by Shay begins here.
 [  19: refused to sit with the thankful soldiers                                                         ]
 [  20: player tried to help, fled - soldiers transformed, these specific gryphons pissed at the player   ]
 [  30: player watched the gryphons do their thing                                                        ]
+[  31: gryphon player talked to the soldier gryphons                                                     ]
+[  32: gryphon player avoided the soldier gryphons                                                       ]
+[  33: human player talked to soldier gryphons                                                           ]
+[  34: infected player talked to soldier gryphons                                                        ]
+[  35: player avoided soldier gryphons                                                                   ]
 [  40: player watched the gryphons do their thing and joined in for the submission                       ]
+[  41: player submitted to the vengeful soldier gryphons                                                 ]
+[  42: player fought off the vengeful soldier gryphons                                                   ]
+[  43: player lost to the vengeful soldier gryphons                                                      ]
+[  44: player fled from to the vengeful soldier gryphons                                                 ]
+[  45: player didn't speak to soldier gryphons                                                           ]
 [  50: player helped the gryphons                                                                        ]
 [  51: player fought off vengeful soldier gryphons                                                       ]
 [  58: player ran from vengeful soldier gryphons                                                         ]
@@ -20,8 +30,6 @@ Version 2 of Gryphons Plot by Shay begins here.
 [  90: player tried to help, failed - soldiers transformed, these specific gryphons pissed at the player ]
 [  91: player got a thanks from the soldier gryphons for trying to help                                  ]
 [ 100: player had no interest, event resolved                                                            ]
-
-GryphPlotTracking is a number that varies.
 
 Table of GameEventIDs (continued)
 Object	Name
@@ -35,7 +43,7 @@ when play begins:
 	add Gryphon's Plot to BadSpots of FurryList;
 
 instead of resolving a Gryphon's Plot:
-	if GryphPlotTracking is 0 or GryphPlotTracking is 1: [first time or repeat after failing to find them]
+	if Resolution of Gryphon's Plot is 0 or Resolution of Gryphon's Plot is 1: [first time or repeat after failing to find them]
 		say "     As you make your way through the city, a loud screeching noise catches your attention. Your eyes quickly survey the immediate area, the noise sounding awfully close to one a gryphon would make. As another screech joins the first, you realize that not just one gryphon is involved. As the gryphon's calls transform from warning to aggressive, you find yourself wondering what is going on, and if you should take a risk in order to find out. The area being filled with many buildings, it is likely the sound may be bouncing off of them, which could lead to you being misled. Despite this, you conclude that finding the source would be difficult, but not impossible.";
 		say "     Of course, the question is, do you want to?[line break]";
 		LineBreak;
@@ -80,20 +88,16 @@ instead of resolving a Gryphon's Plot:
 						increase GroupFightCounter by 1;
 					if fightoutcome < 20: [player won]
 						say "[PlayerWinsVsGryphonPlot1]";
-						now GryphPlotTracking is 10; [player helped the soldiers]
 						now Resolution of Gryphon's Plot is 10; [player helped the soldiers]
 					else if fightoutcome > 19 and fightoutcome < 30: [lost]
 						say "[PlayerLosesVsGryphonPlot1]";
-						now GryphPlotTracking is 90; [player tried to help, failed - soldiers transformed, these specific gryphons pissed at the player]
 						now Resolution of Gryphon's Plot is 90; [player tried to help, failed - soldiers transformed, these specific gryphons pissed at the player]
 					else if fightoutcome is 90: [fled]
 						say "[PlayerFleesVsGryphonPlot1]";
-						now GryphPlotTracking is 20; [player tried to help, failed - soldiers transformed, these specific gryphons pissed at the player]
-						now Resolution of Gryphon's Plot is 20; [player tried to help, failed - soldiers transformed, these specific gryphons pissed at the player]
+						now Resolution of Gryphon's Plot is 20; [player tried to help, fled - soldiers transformed, these specific gryphons pissed at the player]
 				else if calcnumber is 2: [helping the gryphons]
 					LineBreak;
 					say "[PlayerHelpsGryphonPlot1]";
-					now GryphPlotTracking is 50; [player helped the gryphons]
 					now Resolution of Gryphon's Plot is 50; [player helped the gryphons]
 				else if calcnumber is 3: [watching]
 					LineBreak;
@@ -101,20 +105,17 @@ instead of resolving a Gryphon's Plot:
 				else: [leaving]
 					LineBreak;
 					say "     Taking one last look at the scene you decide, the situation clearly isn't your problem. Quietly stepping back, you wander away slowly to avoid to attracting any unwanted attention to yourself. Soon, you are well out of sight of the event as the screeching and other noises die down. Although you didn't wish to be involved, a part of you can't help but wonder how things worked out. Despite the fact that you are curious, you decide that alone isn't enough to go back and possibly run into any trouble that may still linger there. Forcibly pushing the recent event out of mind, you continue on your merry way.";
-					now GryphPlotTracking is 100; [player had no interest]
 					now Resolution of Gryphon's Plot is 100; [player had no interest]
 					now Gryphon's Plot is Resolved; [event will not come up again]
 			else: [not perceptive enough / unlucky]
 				say "     Setting out in search of where the gryphons are, you wander through the deserted streets. Some time later, as you continue trekking through the cities['] rubble for the source of the noise, all sounds eventually cease. Hm, seems like you won't find that group of gryphons today. Maybe if you were a bit more perceptive, you might have found a quicker way to get to them...";
-				now GryphPlotTracking is 1; [player failed to find them]
 				now Resolution of Gryphon's Plot is 1; [player failed to find them]
 		else: [refused to investigate]
 			LineBreak;
 			say "     With a shrug, you try to ignore the noises and concentrate on your immediate surroundings instead. Surviving in the city is difficult enough without actively going out to find trouble...";
-			now GryphPlotTracking is 100; [player had no interest]
 			now Resolution of Gryphon's Plot is 100; [player had no interest]
 			now Gryphon's Plot is Resolved; [event will not come up again]
-	else if GryphPlotTracking is 10: [player helped the soldiers, gryphons are pissed]
+	else if Resolution of Gryphon's Plot is 10: [player helped the soldiers, gryphons are pissed]
 		say "     As you wander through the streets of the creature-infested city, you stumble upon a group of non-infected human soldiers. Inching forward to take a closer look, something inside your head clicks. You knew they looked familiar, it is the soldiers you saved from the gryphons awhile back! One of the men spots you and waves you over, patting a place on the ground beside him.";
 		say "     Do you join them?";
 		LineBreak;
@@ -132,20 +133,17 @@ instead of resolving a Gryphon's Plot:
 				LineBreak;
 				say "[bold type]You gain 3 units of food![roman type][line break]";
 				increase carried of food by 3;
-				now GryphPlotTracking is 11; [helped the soldiers beat up the gryphons]
 				now Resolution of Gryphon's Plot is 11; [helped the soldiers beat up the gryphons]
 			else:
 				LineBreak;
 				say "     Turning the soldiers down, you watch as the looks on their faces instantly turn from happy to disappointed. Rising from your place on the ground, you say your goodbyes to the men. They see you off with solemn waves as you continue along your merry way.";
-				now GryphPlotTracking is 18; [refused to help the soldiers beat up the gryphons]
 				now Resolution of Gryphon's Plot is 18; [refused to help the soldiers beat up the gryphons]
 		else:
 			LineBreak;
 			say "     Deciding that you want nothing to do with whatever the men are up to, you turn your back on the soldier's offer. Surprised by your reaction, but not deterred, they grudgingly, but determinedly, return to their task as you continue along your merry way.";
-			now GryphPlotTracking is 19; [refused to sit with them]
 			now Resolution of Gryphon's Plot is 19; [refused to sit with them]
 			now Gryphon's Plot is Resolved; [event will not come up again]
-	else if GryphPlotTracking is 30: [player watched the gryphons, soldiers are transformed]
+	else if Resolution of Gryphon's Plot is 30: [player watched the gryphons, soldiers are transformed]
 		say "     Walking through the ruins of the city, you come across a sight that you don't see all that often. Three gryphons huddled around a slowly dying fire ahead of you are wearing torn and stained army uniforms, telling you that the men haven't been transformed all that long, or at least have not succumbed to the infection yet, likely retaining much of their original personality. Then things click in your mind, and you remember the soldiers in that jeep being attacked by gryphons. This must be them!";
 		if BodyName of Player is "Blue Gryphon Herm" and player is pure:
 			say "     Being a gryphon yourself, you can't help but feel like the guys might react badly to your presence. Still, do you want to approach them?";
@@ -159,7 +157,7 @@ instead of resolving a Gryphon's Plot:
 			else:
 				LineBreak;
 				say "     Deciding that it is not worth the trouble, you leave the gathering of men and continue along your way throughout the city. After all, you have enough trouble as it is, why go actively look for it?";
-				now Resolution of Gryphon's Plot is 32; [gryphon player avoided to the soldier gryphons]
+				now Resolution of Gryphon's Plot is 32; [gryphon player avoided the soldier gryphons]
 		else:
 			say "     Do you want to approach them and have a chat?";
 			LineBreak;
@@ -183,9 +181,9 @@ instead of resolving a Gryphon's Plot:
 			else:
 				LineBreak;
 				say "     Deciding that it is not worth the trouble, you leave the gathering of men and continue along your way throughout the city.";
-				now Resolution of Gryphon's Plot is 34; [player avoided soldier gryphons]
+				now Resolution of Gryphon's Plot is 35; [player avoided soldier gryphons]
 				now Gryphon's Plot is Resolved; [event will not come up again]
-	else if GryphPlotTracking is 40: [player watched the gryphons, soldiers are transformed, and the player joined in for the submission]
+	else if Resolution of Gryphon's Plot is 40: [player watched the gryphons, soldiers are transformed, and the player joined in for the submission]
 		say "     Walking through the ruins of the city, you come across a sight that you don't see all that often. Three gryphons huddled around a slowly dying fire ahead of you are wearing torn and stained army uniforms, telling you that the men haven't been transformed all that long, or at least have not succumbed to the infection yet, likely retaining much of their original personality. Then things click in your mind, and you remember the soldiers in that jeep being attacked by gryphons. This must be them!";
 		say "     Do you want to approach them and have a chat?";
 		LineBreak;
@@ -241,12 +239,12 @@ instead of resolving a Gryphon's Plot:
 					now Resolution of Gryphon's Plot is 43; [player lost to the vengeful soldier gryphons]
 				else if fightoutcome is 90: [fled]
 					say "     Not having much faith in your ability to fight the men off, you flee. The soldiers donning unattended hard-ons shout curses in your direction in the wake of your successful escape...";
-					now Gryphon's Plot is Resolved; [event will not come up again]
 					now Resolution of Gryphon's Plot is 44; [player fled from to the vengeful soldier gryphons]
+					now Gryphon's Plot is Resolved; [event will not come up again]
 		else:
 			say "     With a shrug you turn you turn your back on the group of gryphons and walk off down the street.";
 			now Resolution of Gryphon's Plot is 45; [player didn't speak to soldier gryphons]
-	else if GryphPlotTracking is 50: [player helped the gryphons, soldiers are transformed]
+	else if Resolution of Gryphon's Plot is 50: [player helped the gryphons, soldiers are transformed]
 		say "     Wandering through the ruins of the city, you see an unusual sight: There is a group of gryphons, still wearing the tattered remains of army uniforms upon their bodies as they sit huddled around a fire. Inching closer to the unlikely scene, you accidentally step on an empty aluminum can, causing the gryphon soldiers to jerk up in alarm as they are alerted to your presence. Spotting you, one of the gryphons exclaim, 'Hey, I know you. You are the one who helped those other gryphons make me like this! Let's see how strong you are without your friends along. Come on, guys, let's get [']em!' Seeing no other option than to fight, you ready your weapon.";
 		let GroupFightCounter be 0;
 		now fightoutcome is 0; [reset]
@@ -264,7 +262,6 @@ instead of resolving a Gryphon's Plot:
 			LineBreak;
 			say "[bold type]You gain 2 units of food![roman type][line break]";
 			increase carried of food by 2;
-			now GryphPlotTracking is 51; [player fought off vengeful soldier gryphons]
 			now Resolution of Gryphon's Plot is 51; [player fought off vengeful soldier gryphons]
 		else if fightoutcome > 19 and fightoutcome < 30: [lost]
 			say "     Not strong enough to single-handedly defeat the vengeful group of gryphons, you fall to your knees, the loser of the battle. With pleased smirks, the soldiers converge upon you, two of them taking turns beating you as the third helps himself to any items he wants from your pack. Between the two of them, it isn't long before you have thoroughly learned your lesson, falling into a state of unconsciousness.";
@@ -281,19 +278,16 @@ instead of resolving a Gryphon's Plot:
 				decrease carried of water bottle by 3;
 			else:
 				say "     You wake three hours later, your body stiff as you collect your pack, which you notice has the same heft as before. You guess that despite the gryphons taking apart its contents, they couldn't find anything that they wanted. Shrugging your shoulders at the fact and ignoring the protests of your thoroughly bruised body, you slowly, but surely, continue along your way, making a note in your head to try and avoid the soldiers should you encounter them in the near future...";
-				now GryphPlotTracking is 59; [player got a beating from vengeful soldier gryphons]
 				now Resolution of Gryphon's Plot is 59; [player got a beating from vengeful soldier gryphons]
 		else if fightoutcome is 90: [fled]
 			say "     Not having much faith in your ability to fight the men off, you flee, the soldiers cursing at you as you disappear into the distance...";
-			now GryphPlotTracking is 58; [player ran from the vengeful soldier gryphons]
 			now Resolution of Gryphon's Plot is 58; [player ran from the vengeful soldier gryphons]
 			now Gryphon's Plot is Resolved; [event will not come up again]
-	else if GryphPlotTracking is 90 or GryphPlotTracking is 20: [player tried to help, failed, gryphons are pissed]
+	else if Resolution of Gryphon's Plot is 90 or Resolution of Gryphon's Plot is 20: [player tried to help, failed, gryphons are pissed]
 		say "     Wandering through the ruins of the city, you see an unusual sight: There is a group of gryphons, still wearing the tattered remains of army uniforms upon their bodies as they sit huddled around a fire. Inching closer to the unlikely scene, you accidentally step on an empty aluminum can, causing the gryphon soldiers to jerk up in alarm as they are alerted to your presence. Spotting you, one of the gryphons exclaims, 'Hey, I know you. You tried to help us fight the gryphons off that one day. Don't worry about the fact that you didn't succeed. We still appreciate that you tried. Besides, all of us are starting to like our new forms anyway. I always wanted to fly when I was a kid. Granted, I was thinking it would be as an airplane pilot, but you know, growing wings of my own I guess is the next best thing.' The soldier then reaches into his pack, pulling out three MREs and hands them to you with a wink. 'For the road, kid. Good luck out there.' With that said, he returns to his seat near their makeshift fire, as you continue on your way, three MREs richer than before...";
 		LineBreak;
 		say "[bold type]You gain 3 units of food![roman type][line break]";
 		increase carried of food by 3;
-		now GryphPlotTracking is 91; [player got a thanks from the soldier gryphons for trying to help]
 		now Resolution of Gryphon's Plot is 91; [player got a thanks from the soldier gryphons for trying to help]
 		now Gryphon's Plot is Resolved; [event will not come up again]
 
@@ -499,11 +493,9 @@ to say PlayerWatchesGryphonPlot1: [player observes the gryphons]
 		fimpregchance;
 		mimpregchance;
 		mimpregchance;
-		now GryphPlotTracking is 40; [player watched the gryphons do their thing and joined in for the submission]
 		now Resolution of Gryphon's Plot is 40; [player watched the gryphons do their thing and joined in for the submission]
 	else:
 		say "     Deciding not to risk it, you silently get up from your hiding place and start to make your way to a safe distance from the scene. You can still hear the sounds of the gryphons['] orgy, as you continue along your way through the ruins of the infested city...";
-		now GryphPlotTracking is 30; [player watched the gryphons do their thing]
 		now Resolution of Gryphon's Plot is 30; [player watched the gryphons do their thing]
 
 Gryphons Plot ends here.

--- a/Shay/Gryphons Plot.i7x
+++ b/Shay/Gryphons Plot.i7x
@@ -31,6 +31,11 @@ Version 2 of Gryphons Plot by Shay begins here.
 [  91: player got a thanks from the soldier gryphons for trying to help                                  ]
 [ 100: player had no interest, event resolved                                                            ]
 
+a postimport rule: [bugfixing rules for players that import savegames]
+	let ResolvedGryphPlotList be {11, 18, 31, 32, 33, 34, 41, 42, 43, 45, 51, 59}; [list of missed resolutions]
+	if Gryphon's Plot is not resolved and Resolution of Gryphon's Plot is listed in ResolvedGryphPlotList:
+		now Gryphon's Plot is resolved; [Just resolve it]
+
 Table of GameEventIDs (continued)
 Object	Name
 Gryphon's Plot	"Gryphon's Plot"
@@ -142,7 +147,7 @@ instead of resolving a Gryphon's Plot:
 			LineBreak;
 			say "     Deciding that you want nothing to do with whatever the men are up to, you turn your back on the soldier's offer. Surprised by your reaction, but not deterred, they grudgingly, but determinedly, return to their task as you continue along your merry way.";
 			now Resolution of Gryphon's Plot is 19; [refused to sit with them]
-			now Gryphon's Plot is Resolved; [event will not come up again]
+		now Gryphon's Plot is Resolved; [event will not come up again]
 	else if Resolution of Gryphon's Plot is 30: [player watched the gryphons, soldiers are transformed]
 		say "     Walking through the ruins of the city, you come across a sight that you don't see all that often. Three gryphons huddled around a slowly dying fire ahead of you are wearing torn and stained army uniforms, telling you that the men haven't been transformed all that long, or at least have not succumbed to the infection yet, likely retaining much of their original personality. Then things click in your mind, and you remember the soldiers in that jeep being attacked by gryphons. This must be them!";
 		if BodyName of Player is "Blue Gryphon Herm" and player is pure:
@@ -182,7 +187,7 @@ instead of resolving a Gryphon's Plot:
 				LineBreak;
 				say "     Deciding that it is not worth the trouble, you leave the gathering of men and continue along your way throughout the city.";
 				now Resolution of Gryphon's Plot is 35; [player avoided soldier gryphons]
-				now Gryphon's Plot is Resolved; [event will not come up again]
+		now Gryphon's Plot is Resolved; [event will not come up again]
 	else if Resolution of Gryphon's Plot is 40: [player watched the gryphons, soldiers are transformed, and the player joined in for the submission]
 		say "     Walking through the ruins of the city, you come across a sight that you don't see all that often. Three gryphons huddled around a slowly dying fire ahead of you are wearing torn and stained army uniforms, telling you that the men haven't been transformed all that long, or at least have not succumbed to the infection yet, likely retaining much of their original personality. Then things click in your mind, and you remember the soldiers in that jeep being attacked by gryphons. This must be them!";
 		say "     Do you want to approach them and have a chat?";
@@ -240,10 +245,10 @@ instead of resolving a Gryphon's Plot:
 				else if fightoutcome is 90: [fled]
 					say "     Not having much faith in your ability to fight the men off, you flee. The soldiers donning unattended hard-ons shout curses in your direction in the wake of your successful escape...";
 					now Resolution of Gryphon's Plot is 44; [player fled from to the vengeful soldier gryphons]
-					now Gryphon's Plot is Resolved; [event will not come up again]
 		else:
 			say "     With a shrug you turn you turn your back on the group of gryphons and walk off down the street.";
 			now Resolution of Gryphon's Plot is 45; [player didn't speak to soldier gryphons]
+		now Gryphon's Plot is Resolved; [event will not come up again]
 	else if Resolution of Gryphon's Plot is 50: [player helped the gryphons, soldiers are transformed]
 		say "     Wandering through the ruins of the city, you see an unusual sight: There is a group of gryphons, still wearing the tattered remains of army uniforms upon their bodies as they sit huddled around a fire. Inching closer to the unlikely scene, you accidentally step on an empty aluminum can, causing the gryphon soldiers to jerk up in alarm as they are alerted to your presence. Spotting you, one of the gryphons exclaim, 'Hey, I know you. You are the one who helped those other gryphons make me like this! Let's see how strong you are without your friends along. Come on, guys, let's get [']em!' Seeing no other option than to fight, you ready your weapon.";
 		let GroupFightCounter be 0;
@@ -282,7 +287,7 @@ instead of resolving a Gryphon's Plot:
 		else if fightoutcome is 90: [fled]
 			say "     Not having much faith in your ability to fight the men off, you flee, the soldiers cursing at you as you disappear into the distance...";
 			now Resolution of Gryphon's Plot is 58; [player ran from the vengeful soldier gryphons]
-			now Gryphon's Plot is Resolved; [event will not come up again]
+		now Gryphon's Plot is Resolved; [event will not come up again]
 	else if Resolution of Gryphon's Plot is 90 or Resolution of Gryphon's Plot is 20: [player tried to help, failed, gryphons are pissed]
 		say "     Wandering through the ruins of the city, you see an unusual sight: There is a group of gryphons, still wearing the tattered remains of army uniforms upon their bodies as they sit huddled around a fire. Inching closer to the unlikely scene, you accidentally step on an empty aluminum can, causing the gryphon soldiers to jerk up in alarm as they are alerted to your presence. Spotting you, one of the gryphons exclaims, 'Hey, I know you. You tried to help us fight the gryphons off that one day. Don't worry about the fact that you didn't succeed. We still appreciate that you tried. Besides, all of us are starting to like our new forms anyway. I always wanted to fly when I was a kid. Granted, I was thinking it would be as an airplane pilot, but you know, growing wings of my own I guess is the next best thing.' The soldier then reaches into his pack, pulling out three MREs and hands them to you with a wink. 'For the road, kid. Good luck out there.' With that said, he returns to his seat near their makeshift fire, as you continue on your way, three MREs richer than before...";
 		LineBreak;

--- a/Speedlover/Kyrverth.i7x
+++ b/Speedlover/Kyrverth.i7x
@@ -29,18 +29,15 @@ Add first ending, add cock/wing/horns tf to description (for later inclusion), a
 [Don't use any of these refs, they are not owned by FS.]
 
 
-KyrverthRoomConnection is a number that varies.[@Tag:NotSaved]
-an everyturn rule: [bugfixing rules for players that import savegames]
+a postimport rule: [bugfixing rules for players that import savegames]
 	if KyrverthStage > 0 and SilverToken is 0 and PlayerFriended of Kyrverth is false and Resolution of Jewel Heist is 0 and Jewel Heist is resolved: [player on the quest, hasn't got the token on them and hasn't handed it in either - so Jewel Heist should be unresolved]
 		now Jewel Heist is not resolved;
 	if KyrverthStage > 0 and Jewel Heist is inactive:
 		now Jewel Heist is active;
 	if Resolution of Strange Sighting is 0 and Strange Sighting is active:
 		now Strange Sighting is not resolved;
-	if Strange Sighting is resolved and Resolution of Strange Sighting is 2 and KyrverthRoomConnection is 0: [event resolved the right way, room not connected yet]
-		change the South exit of Overgrown Street to Dragons Den;
-		change the North exit of Dragons Den to Overgrown Street;
-		now KyrverthRoomConnection is 1; [make sure that it connects the room only once]
+	if Strange Sighting is resolved and Resolution of Strange Sighting is 2: [event resolved the right way, room not connected yet]
+		connect Dragons Den;
 
 Section 1 - Basic Setup
 
@@ -126,6 +123,10 @@ to say DragonsDenDesc:
 			say "     In the center of the room the large nest he made has been broken and remade. Now it is a heap of chainmail, and dragon [if KyrverthQuestHairGiven is true]hair[else]scales[end if] that he curls around at night, safe in the knowledge it cannot be taken without waking him. Bits of chainmail and dragon [if KyrverthQuestHairGiven is true]hair[else]scales[end if] are revealed when Kyrverth wakes, and glint in the light shining through the vault door, making patterns on the walls.";
 	else if KyrverthStage >= 4: [Stages 4, 5, or 6.]
 		say "     This pile of rubble is all that remains of the former bank. Larger pieces have been pushed out to the edge to create a nest of sorts, and in the center the former vault has had its walls split and pushed out in all directions, then flattened down to be the new floor. A hoard is in the center, containing all that is precious to Kyrverth, but you rarely see it as he spends most of his time curled around the former vault to protect it.";
+
+to connect Dragons Den:
+	change the South exit of Overgrown Street to Dragons Den;
+	change the North exit of Dragons Den to Overgrown Street;
 
 to say KyrverthDesc:
 	if KyrverthStage is 0:
@@ -623,8 +624,7 @@ Instead of resolving a Strange Sighting: [Very first meeting with the dragon]
 		increase carried of soda by 1;
 		WaitLineBreak;
 		now PlayerMet of Kyrverth is true;
-		change the South exit of Overgrown Street to Dragons Den;
-		change the North exit of Dragons Den to Overgrown Street;
+		connect Dragons Den;
 		move player to Grey Abbey Library;
 		increase score by 2;
 		now KyrverthLockoutTimer is (turns + 4);

--- a/Stripes/Wereraptor.i7x
+++ b/Stripes/Wereraptor.i7x
@@ -107,7 +107,7 @@ Instead of resolving a Paleontology Professor:
 					challenge "Wereraptor";
 					raptorrelease;
 					if fightoutcome >= 10 and fightoutcome <= 19:
-						say "     Managing to drive off the raptor creature, you take a moment to survey the office. I has been destroyed by the clawed menace trapped inside. The furniture is largely destroyed, the walls and door covered in slashes and everything a mess. Among the wreckage, there's a shattered display case with a large bone lying among the shards. Speaking of the door though, you are confused as you examine it, seeing the nails barring it were driven in from the inside as if the creature sealed itself away. Your search of the office does provide one small reward as you find a bag of stale chips in one of the drawers.";
+						say "     Managing to drive off the raptor creature, you take a moment to survey the office. It has been destroyed by the clawed menace trapped inside. The furniture is largely destroyed, the walls and door covered in slashes and everything a mess. Among the wreckage, there's a shattered display case with a large bone lying among the shards. Speaking of the door though, you are confused as you examine it, seeing the nails barring it were driven in from the inside as if the creature sealed itself away. Your search of the office does provide one small reward as you find a bag of stale chips in one of the drawers.";
 						now UtahGender is 1;
 						increase score by 25;
 						increment carried of chips;
@@ -137,7 +137,7 @@ Instead of resolving a Paleontology Professor:
 					challenge "Wereraptor";
 					raptorrelease;
 					if fightoutcome >= 10 and fightoutcome <= 19:
-						say "     Managing to drive off the raptor creature, you take a moment to survey the office. I has been destroyed by the clawed menace trapped inside. The furniture is largely destroyed, the walls and door covered in slashes and everything a mess. Among the wreckage, there's a shattered display case with a large bone lying among the shards. Speaking of the door though, you are confused as you examine it, seeing the nails barring it were driven in from the inside as if the creature sealed itself away. Your search of the office does provide one small reward as you find a bag of stale chips in one of the drawers.";
+						say "     Managing to drive off the raptor creature, you take a moment to survey the office. It has been destroyed by the clawed menace trapped inside. The furniture is largely destroyed, the walls and door covered in slashes and everything a mess. Among the wreckage, there's a shattered display case with a large bone lying among the shards. Speaking of the door though, you are confused as you examine it, seeing the nails barring it were driven in from the inside as if the creature sealed itself away. Your search of the office does provide one small reward as you find a bag of stale chips in one of the drawers.";
 						now UtahGender is 2;
 						increase score by 25;
 						increment carried of chips;

--- a/UrsaOmega/Campus Gym.i7x
+++ b/UrsaOmega/Campus Gym.i7x
@@ -11,13 +11,9 @@ Campus Gym by UrsaOmega begins here.
 
 ]
 
-CampusGymConnection is a number that varies.[@Tag:NotSaved]
-
-an everyturn rule: [bugfixing rules for players that import savegames]
-	if Working Out is resolved and CampusGymConnection is 0: [event resolved the right way, room not connected yet]
-		change southwest exit of Athletic Street to Campus Gym;
-		change northeast exit of Campus Gym to Athletic Street;
-		now CampusGymConnection is 1; [make sure that it connects the room only once]
+a postimport rule: [bugfixing rules for players that import savegames]
+	if Working Out is resolved: [event resolved the right way, room not connected yet]
+		connect Campus Gym;
 
 Section 1 - Finding the gym
 
@@ -36,8 +32,7 @@ Instead of resolving a Working Out:
 		now Campus Gym is known;
 	else:
 		say "You mark the location on your map - it might be worth checking out later.";
-	change southwest exit of Athletic Street to Campus Gym;
-	change northeast exit of Campus Gym to Athletic Street;
+	connect Campus Gym;
 	now Working Out is resolved;
 
 Section 2 - Campus Gym
@@ -52,6 +47,10 @@ The description of Campus Gym is "The interior of the gym is in even better shap
 
 instead of sniffing Campus Gym:
 	say "The room smells like sweat and hard work.";
+
+to connect Campus Gym:
+	change southwest exit of Athletic Street to Campus Gym;
+	change northeast exit of Campus Gym to Athletic Street;
 
 Section 3 - Randy
 


### PR DESCRIPTION
### Purpose of this PR

### GamePlay Changes
- **Gryphons Plot**: The event should now be resolved properly.
- **Wereraptor**: Fixed a typo.
- **Shifting**: Shifting room now has an exit and the room connection will now always survive an export/import.
- **Zephyr Inc**: No more Zephyr Inc radio ad after an import.

### Internal changes
- Removed the Redundant value `GryphPlotTracking` in favor of using `Resolution of Gryphon's Plot`
- Added a rolebook for `postimport` rules which is being executed after an import.

  Example usages:

  ```inform7
  a postimport rule: [bugfixing rules for players that import savegames]
  	let ResolvedGryphPlotList be {11, 18, 31, 32, 33, 34, 41, 42, 43, 45, 51, 59}; [list of missed resolutions]
  	if Gryphon's Plot is not resolved and Resolution of Gryphon's Plot is listed in ResolvedGryphPlotList:
  		now Gryphon's Plot is resolved; [Just resolve it]
  ```

  ```inform7
  a postimport rule:
	if Resolution of Secure Area > 0:
		connect Shifting Room;
  ```

- Moved some more room connection fixes from everyturn rules to postimport rules and added `to connect Room Name:` functions to avoid needless copy&paste and so that its simpler to change those room connections later on without the risk of missing one occurrence.

  Example:

  ```inform7
  to connect Shifting Room:
  	change the north exit of Qytat Plaza to Shifting Room;
  	change the south exit of Shifting Room to Qytat Plaza;
  ```

- And I've removed the commented out code relic in the Zephyr Ad code.

### Notes
I've tested a couple of those room connection fixes and reviewed my changes a couple times, but it would be tedious to test every single of those room connections before and after an import so let's just say: It compiles without issues and after reviewing the changes a couple times: They *should* now all work as intended. However: It would be neat, if someone else could look over it before merging.

The gameplay changes cept the typo in the wereraptor file were all tested to work as intended before and after an import.