### PR TITLE
More postimport rules and some debug only fixes

### DIFF
--- a/Core Mechanics/Debugging Tools.i7x
+++ b/Core Mechanics/Debugging Tools.i7x
@@ -282,7 +282,7 @@ understand "allitemcheat" as allitemcheat.
 check allitemcheat:
 	if debugactive is 0, say "You aren't currently debugging!" instead;
 
-carry out itemcheat:
+carry out allitemcheat:
 	repeat with x running through grab objects:
 		increase carried of x by 1;
 

--- a/Core Mechanics/Story Skipper Loose Variables.i7x
+++ b/Core Mechanics/Story Skipper Loose Variables.i7x
@@ -3771,6 +3771,8 @@ to VariableTextLoad:
 		say "Restoring Texts...";
 		read File of TextSave into the Table of GameTexts;
 		repeat with x running from 1 to the number of filled rows in the Table of GameTexts:
+			if there is no TextVarValue in row x of the Table of GameTexts:
+				next;
 			choose row x in the Table of GameTexts;
 			if debugactive is 1:
 				say "Restoring text [TextVarName entry].";
@@ -4011,6 +4013,8 @@ to VariableNumberLoad:
 		say "Restoring Numbers...";
 		read File of NumberSave into the Table of GameNumbers;
 		repeat with x running from 1 to the number of filled rows in the Table of GameNumbers:
+			if there is no numberVarValue in row x of the Table of GameNumbers:
+				next;
 			choose row x in the Table of GameNumbers;
 			if debugactive is 1:
 				say "Restoring Number [NumberVarName entry].";

--- a/Core Mechanics/Story Skipper.i7x
+++ b/Core Mechanics/Story Skipper.i7x
@@ -1053,19 +1053,6 @@ to NoteRestore:
 	else:
 		say "No Note Save File Found!";
 
-to CharacterIconRestore:
-	say "Restoring Character Icons...";
-	AlexIconRestore;
-	HadiyaIconRestore;
-	LeonardIconRestore;
-	RodAndRondaIconRestore;
-	SamIconRestore;
-	ChrisIconRestore;
-	DemonBruteIconRestore;
-	DiegoIconRestore;
-	JayIconRestore;
-	DrMattIconRestore;
-
 to RunPostImportRules:
 	say "Running Post Import Rules...";
 	follow the postimport rules;
@@ -1123,7 +1110,6 @@ to say ProgressionImport:
 	BeastRestore;
 	NoteRestore;
 	VariableLoad;
-	CharacterIconRestore;
 	RunPostImportRules;
 
 Table of GameCharacterIDs (continued)

--- a/Stripes/Alex.i7x
+++ b/Stripes/Alex.i7x
@@ -17,7 +17,7 @@ gettinglee is a number that varies.
 
 the scent of Alex is "[alexscent]".
 
-to AlexIconRestore:
+a postimport rule: [bugfixing rules for players that import savegames]
 	if alexbrunch >= 4:
 		now the icon of Alex is Figure of Alex_icon;
 

--- a/Stripes/Leonard.i7x
+++ b/Stripes/Leonard.i7x
@@ -58,7 +58,7 @@ feline_pride_defeat is a truth state that varies. feline_pride_defeat is usually
 
 the scent of Leonard is "The feline smells strong and manly.".
 
-to LeonardIconRestore:
+a postimport rule: [bugfixing rules for players that import savegames]
 	if HP of Leonard >= 6:
 		now the icon of Leonard is the figure of LeonardViolin_icon;
 

--- a/Stripes/Main Storyline.i7x
+++ b/Stripes/Main Storyline.i7x
@@ -17,7 +17,7 @@ understand "Matt" as Doctor Matt.
 understand "Left Behind Recording of Doctor Matt " as Doctor Matt.
 the icon of Doctor Matt is figure of DrMatt_face_icon.
 
-to DrMattIconRestore:
+a postimport rule: [bugfixing rules for players that import savegames]
 	if HP of Doctor Matt is 100:
 		now the icon of Doctor Matt is figure of pixel;
 

--- a/Stripes/RodAndRonda.i7x
+++ b/Stripes/RodAndRonda.i7x
@@ -119,7 +119,7 @@ The description of Ronda Mallrat is "[rondadesc]".
 The conversation of Ronda is { "empty" }.
 Ronda Mallrat is in Mall Atrium.
 
-to RodAndRondaIconRestore:
+a postimport rule: [bugfixing rules for players that import savegames]
 	if HP of Ronda is 100:
 		now the icon of Rod Mallrat is figure of pixel;
 		now the icon of Ronda is figure of RondaSR_icon;

--- a/Stripes/Sam.i7x
+++ b/Stripes/Sam.i7x
@@ -141,7 +141,7 @@ The conversation of Sam is { "Thanks." }.
 the scent of Sam is "[samscent]".
 samformtalk is a truth state that varies. samformtalk is usually false.
 
-to SamIconRestore:
+a postimport rule: [bugfixing rules for players that import savegames]
 	if HP of Sam >= 30 and HP of Sam <= 49:
 		now icon of Sam is figure of Vixentaur_icon;
 	else if HP of Sam >= 50 and HP of Sam <= 69:

--- a/Stripes/hadiya.i7x
+++ b/Stripes/hadiya.i7x
@@ -97,7 +97,7 @@ The fuckscene of Hadiya is "[sexwithHadiya]".
 the icon of Hadiya is usually Figure of Hadiya_0_icon.
 hgsqc is a number that varies.
 
-to HadiyaIconRestore:
+a postimport rule: [bugfixing rules for players that import savegames]
 	if HP of Hadiya is 11 or HP of Hadiya is 12 or HP of Hadiya >= 61:
 		now the icon of Hadiya is Figure of Hadiya_icon;
 

--- a/Wahn/Chris.i7x
+++ b/Wahn/Chris.i7x
@@ -71,7 +71,7 @@ ChrisPlayerOffspring is a number that varies.
 instead of sniffing Chris:
 	say "     Chris has got an attractive male scent.";
 
-to ChrisIconRestore:
+a postimport rule: [bugfixing rules for players that import savegames]
 	if Libido of Chris is 2:
 		now the icon of Chris is Figure of OrcWarrior_random_icon;
 	else if Libido of Chris is 1:

--- a/Wahn/Demon Brute.i7x
+++ b/Wahn/Demon Brute.i7x
@@ -37,7 +37,7 @@ to say demonbrutedesc:
 	else:
 		say "You see a massive beast ahead, with dark purple skin, a frightening face with slits for nostrils, yellow eyes with red irises, and sharp, intimidating teeth. Three matched pairs of horns crown his head, curved and getting smaller front to back. His entire body is gigantic and muscle-bound, and between his legs hangs a thick cock, flaccid for the time being. Behind that, his massive pair of balls dangle, swollen with cum. He also has a long, spade-tipped tail protruding from his tailbone, which is constantly flicking back and forth. He wears nothing but a grin.";
 
-to DemonBruteIconRestore:
+a postimport rule: [bugfixing rules for players that import savegames]
 	if DBCaptureQuestVar is 6 or DBCaptureQuestVar is 7: [cleansed]
 		now the icon of demon brute is Figure of BrutusGood_icon;
 

--- a/Wahn/Diego.i7x
+++ b/Wahn/Diego.i7x
@@ -39,7 +39,7 @@ The icon of Diego is Figure of Diego_icon.
 
 the linkaction of Diego is "[diegolinkaction]".
 
-to DiegoIconRestore:
+a postimport rule: [bugfixing rules for players that import savegames]
 	if DiegoChanged is 2:
 		now the icon of Diego is Figure of DiegoFem_icon;
 	else if DiegoChanged is 1:

--- a/Wahn/Jay.i7x
+++ b/Wahn/Jay.i7x
@@ -76,7 +76,7 @@ The conversation of Jay is { "<This is nothing but a placeholder!>" }.
 The icon of Jay is Figure of Jay_elf_outfit_icon.
 The scent of Jay is "     Jay must wash regularly, as there is little discernible odor to his skin. What you do detect are motes of cinnamon, spices and a hint of gingerbread, the aroma complementing his appearance. There's also a faint trace of his ursine partner's musk, no doubt courtesy of their frequent lovemaking.".
 
-to JayIconRestore:
+a postimport rule: [bugfixing rules for players that import savegames]
 	if thirst of Jay is 9: [suit delivered]
 		now the icon of Jay is Figure of Jay_suit_icon;
 


### PR DESCRIPTION
### Purpose of this PR
A bunch of fixes that shouldn't affect Gameplay unless you call debugging issues Gameplay issues.

### Gameplay changes
- None

### Internal changes
- Replaced CharacterIconRestore-functions with postimport rules
- Fixed `allitemcheat`.
  Actually `allitemcheat` did nothing and `itemcheat` did what allitemcheat should do. See d032cbb78d12c4eba1a983b2db1361b49711cac4.
- Fixed run-time errors caused by a bunch of empty values when importing with debugging active