### PR TITLE
Turn the Player into implementation

### DIFF
--- a/Core Mechanics/Sex and Infection Functions.i7x
+++ b/Core Mechanics/Sex and Infection Functions.i7x
@@ -108,4 +108,68 @@ to SetInfectionsOf ( Target - a person ) to ( Infection - a text ):
 	now AssSpeciesName of Target is InfectionSpeciesName;
 	now TailSpeciesName of Target is InfectionSpeciesName;
 
+to attributeinfect with ( Infection - a text ):
+	let StoredMonsterID be MonsterID;
+	setmonster Infection;
+	attributeinfect;
+	now MonsterID is StoredMonsterID;
+
+to turn the/-- Player into a/an/-- ( Infection - a text ):
+	if there is no Name of Infection in the Table of Random Critters:
+		say "ERROR: Attempted to set the players infection to '[Infection]'. Please report this on the FS Discord.[line break]";
+		stop the action;
+	let InfectionSpeciesName be GetSpeciesName from Infection;
+	choose a row with Name of Infection in the Table of Random Critters;
+	if Player is not FullyNewTypeInfected: [player doesn't have all new type parts]
+		now BodyName of Player is Infection;
+		now FaceName of Player is Infection;
+		now TailName of Player is Infection;
+		now SkinName of Player is Infection;
+		now CockName of Player is Infection;
+		now BodySpeciesName of Player is InfectionSpeciesName;
+		now FaceSpeciesName of Player is InfectionSpeciesName;
+		now TailSpeciesName of Player is InfectionSpeciesName;
+		now SkinSpeciesName of Player is InfectionSpeciesName;
+		now CockSpeciesName of Player is InfectionSpeciesName;
+		now Body of Player is Body entry;
+		now Face of Player is Face entry;
+		now Tail of Player is Tail entry;
+		now Skin of Player is Skin entry;
+		now Cock of Player is Cock entry;
+		[wiping out the new style parts]
+		now HeadName of Player is "";
+		now TorsoName of Player is "";
+		now BackName of Player is "";
+		now ArmsName of Player is "";
+		now LegsName of Player is "";
+		now AssName of Player is "";
+		now CuntName of Player is "";
+		now HeadSpeciesName of Player is "";
+		now TorsoSpeciesName of Player is "";
+		now BackSpeciesName of Player is "";
+		now ArmsSpeciesName of Player is "";
+		now LegsSpeciesName of Player is "";
+		now AssSpeciesName of Player is "";
+		now CuntSpeciesName of Player is "";
+	else:
+		now HeadName of Player is Infection;
+		now TorsoName of Player is Infection;
+		now BackName of Player is Infection;
+		now ArmsName of Player is Infection;
+		now LegsName of Player is Infection;
+		now AssName of Player is Infection;
+		now TailName of Player is Infection;
+		now CockName of Player is Infection;
+		now CuntName of Player is Infection;
+		now HeadSpeciesName of Player is InfectionSpeciesName;
+		now TorsoSpeciesName of Player is InfectionSpeciesName;
+		now BackSpeciesName of Player is InfectionSpeciesName;
+		now ArmsSpeciesName of Player is InfectionSpeciesName;
+		now LegsSpeciesName of Player is InfectionSpeciesName;
+		now AssSpeciesName of Player is InfectionSpeciesName;
+		now TailSpeciesName of Player is InfectionSpeciesName;
+		now CockSpeciesName of Player is InfectionSpeciesName;
+		now CuntSpeciesName of Player is InfectionSpeciesName;
+	attributeinfect with Infection;
+
 Sex and Infection Functions ends here.

--- a/Core Mechanics/Sex and Infection Functions.i7x
+++ b/Core Mechanics/Sex and Infection Functions.i7x
@@ -110,7 +110,7 @@ to SetInfectionsOf ( Target - a person ) to ( Infection - a text ):
 
 to attributeinfect with ( Infection - a text ):
 	let StoredMonsterID be MonsterID;
-	setmonster Infection;
+	setmonster Infection silently;
 	attributeinfect;
 	now MonsterID is StoredMonsterID;
 

--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -6103,7 +6103,13 @@ to weakrandominfect: [does not bypass researcher protection]
 			break;
 		infect;
 
-to setmonster ( x - text ): [puts an infection (named x) as lead monster for later use]
+to setmonster ( x - text ):
+	setmonster x silence state is 0;
+
+to setmonster ( x - text ) silently: [suppresses the debug output]
+	setmonster x silence state is 1;
+
+to setmonster ( x - text ) silence state is (Silence - a number): [puts an infection (named x) as lead monster for later use]
 	let found be 0;
 	choose row MonsterID in the Table of Random Critters;
 	if Name entry exactly matches the text x, case insensitively:
@@ -6117,7 +6123,7 @@ to setmonster ( x - text ): [puts an infection (named x) as lead monster for lat
 				break;
 	if found is 0:
 		say "ERROR - Creature '[x]' not found. (setmonster)[line break]";
-	else if debugactive is 1:
+	else if debugactive is 1 and Silence is 0:
 		say "DEBUG: Current [']monster['] set to: [MonsterID] = [Name entry][line break]";
 
 Section x - Debug Commands - Not for release

--- a/Taelyn/Avalon Kobold.i7x
+++ b/Taelyn/Avalon Kobold.i7x
@@ -58,7 +58,7 @@ When Play begins:
 	now libido entry is 55; [ Target libido the infection will rise towards. ]
 	now loot entry is ""; [ Dropped item, blank for none. Case sensitive. ]
 	now lootchance entry is 0; [ Percentage chance of dropping loot, from 0-100. ]
-	now scale entry is 3; [ Number 1-5, approx size/height of infected PC body: 1=tiny, 3=avg, 5=huge ]
+	now scale entry is 2; [ Number 1-5, approx size/height of infected PC body: 1=tiny, 3=avg, 5=huge ]
 	now body descriptor entry is "[one of]lean[or]lithe[or]koboldy[or]slender[at random]"; [ Ex: "plump" "fat" "muscled" "strong" "slimy" "gelatinous" "slender". Use [one of] to vary ]
 	now type entry is "[one of]draconic[or]reptilian[or]kobold[at random]"; [ one-word creature type. Ex: feline, canine, lupine, robotic, human... Use [one of] to vary ]
 	now magic entry is false;

--- a/Taelyn/Gildwing Kobold Events.i7x
+++ b/Taelyn/Gildwing Kobold Events.i7x
@@ -39,12 +39,7 @@ to say KoboldInfectionMenu:
 	else if calcnumber is 2:
 		say "[KoboldScaleMenu]";
 	else if calcnumber is 3:
-		now scalevalue of player is 2;
-		now BodyName of player is "Avalon Kobold";
-		now FaceName of player is "Avalon Kobold";
-		now TailName of player is "Avalon Kobold";
-		now SkinName of player is "Avalon Kobold";
-		now CockName of player is "Avalon Kobold";
+		turn the Player into an "Avalon Kobold";
 	else if calcnumber is 4:
 		say "[KoboldSelectiveMenu]";
 	else if calcnumber is 5:
@@ -607,8 +602,6 @@ to say GildwingClanAccept:
 			LineBreak;
 		[Skin]
 		say "     Your skin begins to itch horribly as [if KoboldScaleColor is 1]rose-red[else if KoboldScaleColor is 2]azure[else if KoboldScaleColor is 3]forest-green[else if KoboldScaleColor is 4]charcoal-black[else if KoboldScaleColor is 5]snowy-white[else](Error, value invalid. Please report this issue to the FS Discord Server with KoboldScaleColor: [KoboldScaleColor].)[end if] scales form to cover your whole body. They interlock and smooth out and leaving you with sleek, [if KoboldScaleColor is 1]red[else if KoboldScaleColor is 2]blue[else if KoboldScaleColor is 3]green[else if KoboldScaleColor is 4]black[else if KoboldScaleColor is 5]white[else](Error, value invalid. Please report this issue to the FS Discord Server with KoboldScaleColor: [KoboldScaleColor].)[end if], kobold scales.";
-		now SkinName of player is "Avalon Kobold";
-		now Skin of Player is "[if KoboldScaleColor is 1][one of]crimson[or]red[or]rose-red[at random][else if KoboldScaleColor is 2][one of]azure[or]blue[or]sea-blue[at random][else if KoboldScaleColor is 3][one of]verdant[or]green[or]forest-green[at random][else if KoboldScaleColor is 4][one of]obsidian[or]black[or]charcoal-black[at random][else if KoboldScaleColor is 5][one of]alabaster[or]white[or]snow-white[at random][else](Error, value invalid. Please report this issue to the FS Discord Server with KoboldScaleColor: [KoboldScaleColor].)[end if] scales. Despite their protective nature, you can still feel everything just fine through your now draconic";
 		LineBreak;
 		[Chest]
 		if breast size of player > 0:
@@ -618,12 +611,6 @@ to say GildwingClanAccept:
 			LineBreak;
 		[Body]
 		say "     Your legs suddenly collapse underneath you, causing you to fall to your knees. Your legs and feet quiver as they bend and reconfigure into a more draconic digitigrade shape with a three-toed, raptor-like foot. Your hands clench involuntarily as your fingers merge in such a way that you are left with only four fingers instead of five, each tipped with a small claw. Feeling stable again, you push yourself to your feet and try to get used to your new stance.";
-		now BodyName of player is "Avalon Kobold";
-		now Body of Player is "lithe but surprisingly strong. It looks and feels perfect for a cave dwelling Kobold. [if player is female]Besides that, there is also a bit of a feminine curve to your hips, making them somewhat wider for egg laying. [end if]Your legs are digitigrade and end in three-toed feet, while your arms sport four fingered hands, each tipped with a small claw.";
-		now TorsoName of Player is ""; [wiping out the new style parts]
-		now BackName of Player is ""; [wiping out the new style parts]
-		now LegsName of Player is ""; [wiping out the new style parts]
-		now ArmsName of Player is ""; [wiping out the new style parts]
 		LineBreak;
 		[back]
 		[if player:
@@ -631,21 +618,13 @@ to say GildwingClanAccept:
 			LineBreak;]
 		[Tail]
 		say "     A sharp pressure builds at the base of your spine, quickly changing into a strange tingle that shifts outwards, traveling along your new reptilian tail as it settles into its new shape. Wiggling it back and forth, you confirm quickly how well it can move and shift your balance. The perfect tail for a kobold!";
-		now TailName of player is "Avalon Kobold";
-		now tail of player is "A long and agile reptilian tail sways behind you, adjusting to your every movement to help you keep balance. It is surprisingly dexterous and you are able to control your tail as well as any other limb. It seems to wiggle at times when you are happy.";
-		now AssName of Player is ""; [wiping out the new style parts]
 		LineBreak;
 		[Face]
 		say "     Your vision turns blurry and your head aches as it rearranges its shape. Pressure builds at the back of your skull as two small kobold horns grow, and by the time the headache clears and your vision returns, you are met with a small draconic snout with a mouth filled with pointy little teeth, making you look similar to a small dragon.";
-		now FaceName of player is "Avalon Kobold";
-		now Face of Player is "reptilian in shape and crowned with two small horns. Your wide, [Eye Color of player] eyes are surprisingly keen, even while in the dark. Small but sharp teeth and a pointed tongue complete your draconic visage";
-		now HeadName of Player is ""; [wiping out the new style parts]
 		LineBreak;
 		[Cock&Balls]
 		if player is male:
 			say "     Your crotch feels warm as your arousal flares, causing your [if player is internal][Cock of Player] cock to stir within you, slowly pushing its way out from your vent, beginning to pulse as its shape changes to something more fitting for a small lizard. It becomes smooth; tapering down until thickening into a pseudo-knot bulge at the base. As soon as the transformation is complete, the feeling starts to fade, and slowly your new kobold cock withdraws back into your genital slit[else][Cock of Player] cock to harden and grow to its full length, beginning to pulse as its shape starts to change. Your balls pull up, and for a moment you are worried that you are losing them, but you can feel them traveling within you to become internal. At the same time, your dick becomes something more fitting for a small lizard. It becomes smooth; tapering down until thickening into a pseudo-knot bulge at the base. You feel a new depth push inward as a vent is formed to house your new reptilian length. As soon as the transformation is complete, the feeling starts to fade, and slowly your new kobold cock withdraws into your genital slit, leaving it impossible to tell your gender merely by looking at your groin[end if].";
-			now CockName of player is "Avalon Kobold";
-			now Cock of Player is "[one of]reptilian[or]draconic[or]taperd[or]kobold[at random]";
 			WaitLineBreak;
 		[Womb]
 		if (Player is female or Player is mpreg_ok) and ovipregalways is false:
@@ -655,6 +634,7 @@ to say GildwingClanAccept:
 			now ovipreglevel is 3;
 		[]
 		say "     Gildwing looks over your new kobold form with a pleased expression. 'This suits you well,' he says before calling out, 'Tyrin!' The red kobold quickly enters the cavern room, stopping for a moment as soon as he sees you. 'Oh! Our friend decided to join us? Tani will be happy about that.' The dragon gestures towards you. 'Please show [ObjectPro of player] around and explain how [SubjectPro of player] may help.' Tyrin nods and looks towards you. 'Follow me please,' he asks before leading you out into the main passageway.";
+		turn the Player into an "Avalon Kobold";
 		now Resolution of GildwingKoboldTest is 3;
 	else:
 		say "     'As you wish,' he says before calling Tyrin into the room. It isn't long before the red kobold makes his way over and stands next to you. '[if player is not defaultnamed][name of player][else]This new recruit has[end if] decided to join us. Please, show [ObjectPro of player] around and explain [PosAdj of player] role.' Tyrin bows politely to the dragon before turning to you with a slight grin. 'So, you'll be helping to Gildwings? That's good to hear! Follow me, and I'll explain how things work around here.'";


### PR DESCRIPTION
### Purpose of the PR
Create a method aka function to fully turn the player into the desired infection.

### Gameplay changes
- **Avalon Kobold;** `BodyType of Player` will now be set to 'Kobold' as intended.

### Internal changes
- Implemented the function `to turn the/-- Player into a/an/-- ( Infection - a text ):`
  using "Avalon Kobold" as the first example:
  ```inform7
  turn the Player into an "Avalon Kobold";
  ```
- corrected the `now scale entry is 3;` to 2 for Avalon Kobolds
- Optional `setmonster "xyz" silenty;` to optionally suppress debug output.
  (Used in `to attributeinfect with ( Infection - a text ):`

### Notes
Tested it a couple times and everything should run smoothly as intended.
I'll leave it for Avalon Kobold only for now and add more 'turn the Player into a "...";' to the codebase in a later PR.