### PR TITLE
Unwield weapon used for crafting

### DIFF
--- a/Core Mechanics/Basic Functions.i7x
+++ b/Core Mechanics/Basic Functions.i7x
@@ -576,6 +576,14 @@ to FindHighestPlayerStat:
 		now CurrentStat is Perception of Player;
 		now HighestPlayerStat is "perception";
 
+to unwield ( x - a grab object ):
+	if x is an armament and weapon of Player is weapon of x:
+		now weapon of Player is "[one of]your quick wit[or]your fists[or]a quick kick[or]your body[or]some impromptu wrestling[or]an unarmed strike[at random]";
+		now weapon damage of Player is 4;
+		now weapon type of Player is "Melee";
+		now weapon object of Player is journal;
+		say "You stop holding your [x].";
+
 Section 2 - Stripping
 
 [

--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -2910,11 +2910,7 @@ To process (x - a grab object):
 		follow turnpass rule;
 	else if x is a armament:
 		if weapon of Player is weapon of x:		[unequip]
-			now weapon of Player is "[one of]your quick wit[or]your fists[or]a quick kick[or]your body[or]some impromptu wrestling[or]an unarmed strike[at random]";
-			now weapon damage of Player is 4;
-			now weapon type of Player is "Melee";
-			now weapon object of Player is journal;
-			say "You stop holding your [x].";
+			unwield x;
 		else: [equip]
 			now weapon object of Player is x;
 			now weapon of Player is weapon of x;

--- a/Taelyn/Percy.i7x
+++ b/Taelyn/Percy.i7x
@@ -467,11 +467,12 @@ to say PercyCrafting1: [Con 1]
 			LineBreak;
 			say "     You hand Percy the materials who looks them over with experienced eye. 'Hmmm. This knife is old but well made, Likely military. Cold War maybe?' The Pangolin puts the two materials off the side before returning his focus to you. 'Anyways, this shouldn't take too long. I'll have to remove the blade and fasten it to the haft, then secure it with some binding. I should have it done in a [bold type]few hours[roman type].'";
 			LineBreak;
-			say "[bold type]Pocketknife removed.[roman type][line break]";
+			unwield pocketknife;
 			delete pocketknife;
-			LineBreak;
-			say "[bold type]Broke-Ass Hoe removed.[roman type][line break]";
+			say "Pocketknife removed.";
+			unwield Broke-Ass Hoe;
 			delete Broke-Ass Hoe;
+			say "Broke-Ass Hoe removed.";
 			now Strength of Percy is a random number from 2 to 3; [sets the needed time to a random value]
 			now Stamina of Percy is 1;
 			CreditLoss 50;


### PR DESCRIPTION
### Purpose of the PR
When asking Percy to craft the makeshift spear while holding the Pocketknife or the Broke-Ass Hoe the weapons were removed from the inventory but not unwielded.

### Gameplay changes
- **Percy:** When Percy starts crafting the makeshift spear the weapons used for it are now properly unequipped.

### Internal changes
- Added the function `to unwield ( x - a grab object ):` for this.
  Example:
  ```inform7
  unwield Broke-Ass Hoe;
  ```
- Removed the bold tags from "Pocketknife removed." and "Broke-Ass Hoe removed." for the sake of consistency.

### Notes
I've tested this intensively and I made sure, that I've pasted the updated `story.ni` into the Inform 7 IDE before testing.
  