### PR TITLE
To wield or not to wield

### DIFF
--- a/Core Mechanics/Basic Functions.i7x
+++ b/Core Mechanics/Basic Functions.i7x
@@ -579,13 +579,43 @@ to FindHighestPlayerStat:
 		now CurrentStat is Perception of Player;
 		now HighestPlayerStat is "perception";
 
+to unwield ( x - a grab object ) silently:
+	unwield x silence state is 1;
+
 to unwield ( x - a grab object ):
-	if x is an armament and weapon of Player is weapon of x:
+	unwield x silence state is 0;
+
+to unwield ( x - a grab object ) silence state is (Silence - a number):
+	if x is an armament and weapon object of Player is x:
 		now weapon of Player is "[one of]your quick wit[or]your fists[or]a quick kick[or]your body[or]some impromptu wrestling[or]an unarmed strike[at random]";
 		now weapon damage of Player is 4;
 		now weapon type of Player is "Melee";
 		now weapon object of Player is journal;
-		say "You stop holding your [x].";
+		if Silence is 0:
+			say "You stop holding your [x].";
+
+to wield ( x - a grab object ) silently:
+	wield x silence state is 1;
+
+to wield ( x - a grab object ):
+	wield x silence state is 0;
+
+to wield ( x - a grab object ) silence state is (Silence - a number):
+	if x is owned and x is an armament:
+		now weapon object of Player is x;
+		now weapon of Player is weapon of x;
+		now weapon damage of Player is weapon damage of x;
+		now weapon type of Player is weapon type of x;
+		if x is ranged:
+			now weapon type of Player is "Ranged";
+		if Silence is 0:
+			say "You ready your [x]";
+			if x is unwieldy:
+				if scalevalue of Player > objsize of x:
+					say ". Your [if scalevalue of Player is 3]normal-size[else if scalevalue of Player is 4]large[else]massive[end if] [BodyName of Player] hand dwarfs the [x], making it [if scalevalue of Player - objsize of x > 3]very[else if scalevalue of Player - objsize of x is 3]rather[else]somewhat[end if] [one of]unwieldy[or]awkward[or]difficult[at random] to use accurately";
+				else:
+					say ". Your [if scalevalue of Player is 3]normal-size[else if scalevalue of Player is 2]small[else]tiny[end if] [BodyName of Player] hands are just too small to comfortably grip your [x], making swinging it a [if objsize of x - scalevalue of Player > 3]very[else if objsize of x - scalevalue of Player is 3]quite[else]a little[end if] [one of]unwieldy[or]awkward[or]difficult[at random]";
+			say ".";
 
 Section 2 - Stripping
 

--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -2899,22 +2899,10 @@ To process (x - a grab object):
 			now Lastjournaluse is turns;
 		follow turnpass rule;
 	else if x is a armament:
-		if weapon of Player is weapon of x:		[unequip]
+		if weapon object of Player is x: [unequip]
 			unwield x;
 		else: [equip]
-			now weapon object of Player is x;
-			now weapon of Player is weapon of x;
-			now weapon damage of Player is weapon damage of x;
-			now weapon type of Player is weapon type of x;
-			if x is ranged:
-				now weapon type of Player is "Ranged";
-			say "You ready your [x]";
-			if x is unwieldy:
-				if scalevalue of Player > objsize of x:
-					say ". Your [if scalevalue of Player is 3]normal-size[else if scalevalue of Player is 4]large[else]massive[end if] [BodyName of Player] hand dwarfs the [x], making it [if scalevalue of Player - objsize of x > 3]very[else if scalevalue of Player - objsize of x is 3]rather[else]somewhat[end if] [one of]unwieldy[or]awkward[or]difficult[at random] to use accurately";
-				else:
-					say ". Your [if scalevalue of Player is 3]normal-size[else if scalevalue of Player is 2]small[else]tiny[end if] [BodyName of Player] hands are just too small to comfortably grip your [x], making swinging it a [if objsize of x - scalevalue of Player > 3]very[else if objsize of x - scalevalue of Player is 3]quite[else]a little[end if] [one of]unwieldy[or]awkward[or]difficult[at random]";
-			say ".";
+			wield x;
 	else if x is equipment:
 		if x is equipped: [unequip]
 			if x is not cursed: [explanation why the item can't be taken off is to be done in the item description]

--- a/Stripes/Doberman Cop.i7x
+++ b/Stripes/Doberman Cop.i7x
@@ -310,15 +310,9 @@ to say weaponconf:
 				say "She takes your whip and sword away, making sure to grab them using an evidence bag. 'Just think about the damage you could have caused with these. You're too much of a loose cannon to be trusted with them. I cannot allow such weapons to be used unchecked. We should be trying to slow the infection, not spread it faster!'";
 			else:							[lost the fight]
 				say "She takes your whip and sword away, making sure to grab them using an evidence bag. 'I can't let a half-crazed fool like you run around with something like this. You cannot be trusted with something this dangerous and I cannot allow such weapons to be used unchecked. We should be trying to slow the infection, not spread it faster!'";
-			if weapon object of Player is dirty whip:
-				now weapon damage of Player is 4;
-				now weapon type of Player is "Melee";
-				now weapon object of Player is journal;
-			if weapon object of Player is infected sword:
-				now weapon damage of Player is 4;
-				now weapon type of Player is "Melee";
-				now weapon object of Player is journal;
+			unwield dirty whip silently;
 			delete dirty whip;
+			unwield infected sword silently;
 			delete infected sword;
 		else if dirty whip is owned:
 			if dobielibido >= 100 and inasituation is false:
@@ -331,10 +325,7 @@ to say weaponconf:
 				say "She takes your whip away, making sure to grab it using an evidence bag. 'Just think about the damage you could have caused with this. You're too much of a loose cannon to be trusted with it. I cannot allow such weapons to be used unchecked. We should be trying to slow the infection, not spread it faster!'";
 			else:							[lost the fight]
 				say "She takes your whip away, making sure to grab it using an evidence bag. 'I can't let a half-crazed fool like you run around with something like this. You cannot be trusted with something this dangerous and I cannot allow such weapons to be used unchecked. We should be trying to slow the infection, not spread it faster!'";
-			if weapon object of Player is dirty whip:
-				now weapon damage of Player is 4;
-				now weapon type of Player is "Melee";
-				now weapon object of Player is journal;
+			unwield dirty whip silently;
 			delete dirty whip;
 		else if infected sword is owned:
 			if dobielibido >= 100 and inasituation is false:
@@ -347,10 +338,7 @@ to say weaponconf:
 				say "She takes your sword away, making sure to grab it using an evidence bag. 'Just think about the damage you could have caused with this. You're too much of a loose cannon to be trusted with it. I cannot allow such weapons to be used unchecked. We should be trying to slow the infection, not spread it faster!'";
 			else:							[lost the fight]
 				say "She takes your sword away, making sure to grab it using an evidence bag. 'I can't let a half-crazed fool like you run around with something like this. You cannot be trusted with something this dangerous and I cannot allow such weapons to be used unchecked. We should be trying to slow the infection, not spread it faster!'";
-			if weapon object of Player is infected sword:
-				now weapon damage of Player is 4;
-				now weapon type of Player is "Melee";
-				now weapon object of Player is journal;
+			unwield infected sword silently;
 			delete infected sword;
 
 

--- a/Stripes/Wereraptor.i7x
+++ b/Stripes/Wereraptor.i7x
@@ -978,7 +978,7 @@ to say wrcureattempt:
 		WaitLineBreak;
 		say "     You stagger to your feet, feeling very weak and worn from your blood loss, but also as if a great burden has been lifted from you. You watch as the last of your blood bubbles on the fossilized bones and disappears. You're uncertain if it boiled away or was absorbed into the dry bones, but it is gone. In short order, the slashes on your shoulders fade away, healed and gone as if they were never there. Having beaten its power, you know you cannot be tainted by it again.";
 		say "     Not wanting to linger here any longer, you prepare to leave only to notice that the silver knife is missing. You suspect it's somehow already found its way back to Nermine.";
-		if weapon object of Player is silver knife, now weapon object of Player is journal;
+		if weapon object of Player is silver knife, unwield silver knife silently;
 		now carried of silver knife is 0;
 		if humanity of Player < 100:
 			SanBoost 1;
@@ -996,12 +996,12 @@ to say wrcureattempt:
 		else:
 			say "     The wereraptor growls victoriously and grabs the potion with visible trepidation before racing headlong to the balcony overlooking the lower floors. With a hissing laugh, he tosses the vial down as you scream. There is a distance crash as your precious cure is destroyed. Dr. Utah clacks back across the tiled floor and runs his taloned hand across your body. 'Soon you will come to accept your proper nature and forsake your foolish reluctance. It is time for the saurians to rise again, new and stronger.' He leans in closer and runs his tongue along your face. 'I look forward to hunting with you,' he adds with a grope between your legs before turning and leaving.";
 		say "     Once you've recovered enough to stand, you prepare yourself to leave. You glance around and realize that your silver knife is gone. You suspect it's somehow already found its way back to Nermine. With your cure gone and your payment made, you get the feeling that you're on your own now.";
-		if weapon object of Player is silver knife, now weapon object of Player is journal;
+		if weapon object of Player is silver knife, unwield silver knife silently;
 		now carried of silver knife is 0;
 		now wrcurseNermine is 10;
 	else:
 		say "     As you turn and run, the speedy wereraptor makes a final charge and swipes her claws at you. This knocks the potion from your hand, sending it tumbling to the ground and breaking. With its scent in the air, your revulsion kicks in and you move quickly to get away, the transformed professor fleeing as well. When you stop and try to catch your breath now that you're far from the smell of it, you realize that your silver knife is missing as well. You suspect it's somehow already found its way back to Nermine. With your cure gone and your payment made, you get the feeling that you're on your own now.";
-		if weapon object of Player is silver knife, now weapon object of Player is journal;
+		if weapon object of Player is silver knife, unwield silver knife silently;
 		now carried of silver knife is 0;
 		now wrcurseNermine is 10;
 

--- a/Taelyn/Percy.i7x
+++ b/Taelyn/Percy.i7x
@@ -467,12 +467,12 @@ to say PercyCrafting1: [Con 1]
 			LineBreak;
 			say "     You hand Percy the materials who looks them over with experienced eye. 'Hmmm. This knife is old but well made, Likely military. Cold War maybe?' The Pangolin puts the two materials off the side before returning his focus to you. 'Anyways, this shouldn't take too long. I'll have to remove the blade and fasten it to the haft, then secure it with some binding. I should have it done in a [bold type]few hours[roman type].'";
 			LineBreak;
-			unwield pocketknife;
+			unwield pocketknife silently;
 			delete pocketknife;
-			say "Pocketknife removed.";
-			unwield Broke-Ass Hoe;
+			say "[bold type]Pocketknife removed.[roman type][line break]";
+			unwield Broke-Ass Hoe silently;
 			delete Broke-Ass Hoe;
-			say "Broke-Ass Hoe removed.";
+			say "[bold type]Broke-Ass Hoe removed.[roman type][line break]";
 			now Strength of Percy is a random number from 2 to 3; [sets the needed time to a random value]
 			now Stamina of Percy is 1;
 			CreditLoss 50;


### PR DESCRIPTION
### Gameplay changes
- **Doberman Cop:** `weapon of Player` wasn't being set upon unequipping the Dirty Whip and/or the Infected Sword **(Rare case)**.
- **Wereraptor curse:** Unequipping the silver knife after curing the curse now properly resets weapon data to melee.

### Internal changes
- `unwield x`  and `wield x` can be silenced by appending `silently`.
- Added `wield x` for later use in scenes where the player equips a weapon and moved it out of `story.ni` to `Core Mechanics/Basic Functions.i7x`

### Note
Almost forgot that branch when moving to other stuff. Anyway, since this fixes minor issues this could be postponed till after the september release.
