### PR TITLE
Revert FireSprite altcombat entry

### DIFF
--- a/AGentlemanCalledB/Fire Sprite.i7x
+++ b/AGentlemanCalledB/Fire Sprite.i7x
@@ -324,7 +324,7 @@ When Play begins:
 	now non-infectious entry is false;
 	now Cross-Infection entry is ""; [infection that this infection will give the player when they lose; can be left empty if they infect with the monster's own] [ Is this a non-infectious, non-shiftable creature? True/False (usually false) ]
 	now DayCycle entry is 0; [ 0 = Up at all times; 1 = Diurnal (day encounters only); 2 = Nocturnal (night encounters only);]
-	now altcombat entry is "firebreath"; [ Row used to designate any special combat features, "default" for standard combat. ]
+	now altcombat entry is "FireSprite"; [ Row used to designate any special combat features, "default" for standard combat. ]
 	now BannedStatus entry is false;
 
 [


### PR DESCRIPTION
Revert a mistake/oversight, when working myself though all the infection lists, oopsie daisy.
Missed the `Table of Critter Combat (continued)` line in the same file.