### PR TITLE
Fix player stats going out of bounds after accepting wereraptor curse

### DIFF
--- a/Stripes/Wereraptor.i7x
+++ b/Stripes/Wereraptor.i7x
@@ -621,10 +621,10 @@ this is the wereraptor curse rule:
 			else:
 				if wrcurseactivity is true:
 					now wrcurseactivity is false;
-					StatChange "Dexterity" by 2;
-					StatChange "Strength" by 2;
-					StatChange "Charisma" by -2;
-					StatChange "Intelligence" by -2;
+					StatChange "Dexterity" by -2;
+					StatChange "Strength" by -2;
+					StatChange "Charisma" by 2;
+					StatChange "Intelligence" by 2;
 					say "     With the coming of the day, your saurian body spasms and twitches. The feral strength of your wereraptor form recedes for now as your features soften and you take on a form more akin to a reptilian humanoid, hiding your wilder true nature for the moment.";
 
 


### PR DESCRIPTION
### Purpose of the PR
After the player accepted the wereraptor curse and became a 'true' wereraptor the stat changes were messed up. Instead of going up and down the strength and dexterity always went up and the intelligence and charisma always went down with the boundaries being only the unsigned int limits (or even positive or negative infinity?). Fixed that.

### Gameplay fixes
**Wereraptor curse:** The players stats won't go out of bounds anymore after accepting the wereraptor curse.

### Note
Did a brief test in the Inform 7 IDE and it compiles without errors (yay!) and now works as intended.