### PR TITLE
Debugging revamp

### DIFF
--- a/Core Mechanics/Debugging Tools.i7x
+++ b/Core Mechanics/Debugging Tools.i7x
@@ -10,6 +10,7 @@ Version 2 of Debugging Tools by Core Mechanics begins here.
 [ debugactive 1 = Debug on]
 
 debugactive is a number that varies.[@Tag:NotSaved] debugactive is 0.
+debuglevel is a number that varies.[@Tag:NotSaved] debuglevel is 1.
 RandomGenNumber is a number that varies.[@Tag:NotSaved]
 
 [ Todo: write Debug code to display _all_ NPC variables]
@@ -32,6 +33,27 @@ carry out debugmode:
 		if "Debugger" is listed in Traits of Player:
 			remove "Debugger" from Traits of Player;
 		now debugactive is 0;
+
+setdebuglevel is an action applying to one topic.
+understand "debuglevel [text]" as setdebuglevel.
+
+carry out setdebuglevel:
+	let newlevel be 0;
+	now newlevel is numerical value of topic understood;
+	if newlevel < 1 or newlevel > 6:
+		say "ERROR: level has to be between 1 and 6!";
+	else:
+		now debuglevel is newlevel;
+		say "Debug level set to [debuglevel]";
+
+to debug at level ( n - number ) say ( t - text ):
+	if debugactive is 1 and debuglevel >= n:
+		say t;
+
+to decide if debug is at level ( n - number ): [or higher]
+	if debugactive is 0, decide no;
+	if debuglevel < n, decide no;
+	decide yes;
 
 turncountdisplay is an action applying to nothing.
 understand "turn count" as turncountdisplay.

--- a/Core Mechanics/Sex and Infection Functions.i7x
+++ b/Core Mechanics/Sex and Infection Functions.i7x
@@ -173,7 +173,7 @@ to SetInfectionsOf ( Target - a person ) randomized between ( Father - a person 
 		now TailName of Target is TailName of Mother;
 		now TailSpeciesName of Target is TailSpeciesName of Mother;
 
-to attributeinfect with ( Infection - a text ):
+to attributeinfect with/-- ( Infection - a text ):
 	let StoredMonsterID be MonsterID;
 	setmonster Infection silently;
 	attributeinfect;

--- a/Core Mechanics/Story Skipper Loose Variables.i7x
+++ b/Core Mechanics/Story Skipper Loose Variables.i7x
@@ -57,7 +57,8 @@ to VariableSave:
 	repeat with x running from 1 to the number of filled rows in the Table of GameVariableIDs:
 		choose row x in the Table of GameVariableIDs;
 		now CurrentVariableName is Name entry;
-		debug at level 6 say "Stashing variable [CurrentVariableName].";
+		if debug is at level 6:
+			say "Stashing variable [CurrentVariableName].";
 		if Type Entry is "text":
 			TextVariableSave;
 		else if Type Entry is "number":
@@ -71,22 +72,28 @@ to VariableSave:
 		else if Type Entry is "list of numbers":
 			NumberListVariableSave;
 	write File of TextSave from the Table of GameTexts; [freshly made table gets saved to file]
-	debug at level 6 say "TextSave File Written.";
+	if debug is at level 6:
+		say "TextSave File Written.";
 	blank out the whole of Table of GameTexts; [empty out all old data]
 	write File of NumberSave from the Table of GameNumbers; [freshly made table gets saved to file]
-	debug at level 6 say "NumberSave File Written.";
+	if debug is at level 6:
+		say "NumberSave File Written.";
 	blank out the whole of Table of GameNumbers; [empty out all old data]
 	write File of TruthSave from the Table of GameTruths; [freshly made table gets saved to file]
-	debug at level 6 say "TruthSave File Written.";
+	if debug is at level 6:
+		say "TruthSave File Written.";
 	blank out the whole of Table of GameTruths; [empty out all old data]
 	write File of IndexedTextSave from the Table of GameIndexedTexts; [freshly made table gets saved to file]
-	debug at level 6 say "IndexedTextSave File Written.";
+	if debug is at level 6:
+		say "IndexedTextSave File Written.";
 	blank out the whole of Table of GameIndexedTexts; [empty out all old data]
 	write File of TextListSave from the Table of GameTextLists; [freshly made table gets saved to file]
-	debug at level 6 say "TextListSave File Written.";
+	if debug is at level 6:
+		say "TextListSave File Written.";
 	blank out the whole of Table of GameTextLists; [empty out all old data]
 	write File of NumberListSave from the Table of GameNumberLists; [freshly made table gets saved to file]
-	debug at level 6 say "NumberListSave File Written.";
+	if debug is at level 6:
+		say "NumberListSave File Written.";
 	blank out the whole of Table of GameNumberLists; [empty out all old data]
 
 to TextVariableSave:
@@ -3766,8 +3773,12 @@ to VariableTextLoad:
 		say "Restoring Texts...";
 		read File of TextSave into the Table of GameTexts;
 		repeat with x running from 1 to the number of filled rows in the Table of GameTexts:
+			if there is no TextVarValue in row x of the Table of GameTexts:
+				debug at level 4 say "Skipping empty text [TextVarName in row x of the Table of GameTexts].[line break]";
+				next;
 			choose row x in the Table of GameTexts;
-			debug at level 6 say "Restoring text [TextVarName entry].";
+			if debug is at level 6:
+				say "Restoring text [TextVarName entry].";
 			if TextVarName entry is:
 				-- "PronounChoice":
 					now PronounChoice of Player is TextVarValue entry;
@@ -3995,7 +4006,8 @@ to VariableTextLoad:
 					now wrtail is TextVarValue entry;
 				-- "wrTailName":
 					now wrTailName is TextVarValue entry;
-			debug at level 6 say "DEBUG -> VarName '[TextVarName entry]' restored to '[TextVarValue entry]'.";
+			if debug is at level 6:
+				say "DEBUG -> VarName '[TextVarName entry]' restored to '[TextVarValue entry]'.";
 	else:
 		say "No Text Save File Found!";
 
@@ -4004,8 +4016,12 @@ to VariableNumberLoad:
 		say "Restoring Numbers...";
 		read File of NumberSave into the Table of GameNumbers;
 		repeat with x running from 1 to the number of filled rows in the Table of GameNumbers:
+			if there is no numberVarValue in row x of the Table of GameNumbers:
+				debug at level 4 say "Skipping empty Number [NumberVarName in row x of the Table of GameNumbers].[line break]";
+				next;
 			choose row x in the Table of GameNumbers;
-			debug at level 6 say "Restoring Number [NumberVarName entry].";
+			if debug is at level 6:
+				say "Restoring Number [NumberVarName entry].";
 			if NumberVarName entry is:
 				-- "featgained":
 					now featgained of Player is numberVarValue entry;
@@ -6659,7 +6675,8 @@ to VariableNumberLoad:
 					now zigseat is numberVarValue entry;
 				-- "zpc_Zc":
 					now zpc_Zc is numberVarValue entry;
-			debug at level 6 say "DEBUG -> VarName '[NumberVarName entry]' restored to '[NumberVarValue entry]'.";
+			if debug is at level 6:
+				say "DEBUG -> VarName '[NumberVarName entry]' restored to '[NumberVarValue entry]'.";
 	else:
 		say "No Number Save File Found!";
 
@@ -6669,7 +6686,8 @@ to VariableTruthLoad:
 		read File of TruthSave into the Table of GameTruths;
 		repeat with x running from 1 to the number of filled rows in the Table of GameTruths:
 			choose row x in the Table of GameTruths;
-			debug at level 6 say "Restoring Truth [TruthVarName entry].";
+			if debug is at level 6:
+				say "Restoring Truth [TruthVarName entry].";
 			if TruthVarName entry is:
 				-- "A_Candy":
 					now A_Candy is TruthVarValue entry;
@@ -7331,7 +7349,8 @@ to VariableTruthLoad:
 					now zigorhadiyaquest is TruthVarValue entry;
 				-- "zpc_inzone":
 					now zpc_inzone is TruthVarValue entry;
-			debug at level 6 say "DEBUG -> VarName '[TruthVarName entry]' restored to '[TruthVarValue entry]'.";
+			if debug is at level 6:
+				say "DEBUG -> VarName '[TruthVarName entry]' restored to '[TruthVarValue entry]'.";
 	else:
 		say "No Truth Save File Found!";
 
@@ -7341,7 +7360,8 @@ to VariableIndexedTextLoad:
 		read File of IndexedTextSave into the Table of GameIndexedTexts;
 		repeat with x running from 1 to the number of filled rows in the Table of GameIndexedTexts:
 			choose row x in the Table of GameIndexedTexts;
-			debug at level 6 say "Restoring IndexedText [IndexedTextVarName entry].";
+			if debug is at level 6:
+				say "Restoring IndexedText [IndexedTextVarName entry].";
 			if IndexedTextVarName entry is:
 				-- "bcupsize":
 					now bcupsize is IndexedTextVarValue entry;
@@ -7349,7 +7369,8 @@ to VariableIndexedTextLoad:
 					now bmagic is IndexedTextVarValue entry;
 				-- "cupsize":
 					now cupsize is IndexedTextVarValue entry;
-			debug at level 6 say "DEBUG -> VarName '[IndexedTextVarName entry]' restored to '[IndexedTextVarValue entry]'.";
+			if debug is at level 6:
+				say "DEBUG -> VarName '[IndexedTextVarName entry]' restored to '[IndexedTextVarValue entry]'.";
 	else:
 		say "No IndexedText Save File Found!";
 
@@ -7379,7 +7400,8 @@ to VariableTextListLoad:
 					add TextListVarValue entry to lbcompList;
 				-- "ndmlist":
 					add TextListVarValue entry to ndmList;
-			debug at level 6 say "DEBUG -> [x]: Added '[TextListVarValue entry]' to TextList [TextListName].";
+			if debug is at level 6:
+				say "DEBUG -> [x]: Added '[TextListVarValue entry]' to TextList [TextListName].";
 	else:
 		say "No TextList Save File Found!";
 
@@ -7421,7 +7443,8 @@ to VariableNumberListLoad:
 					add NumberListVarValue entry to pfpcList;
 				-- "velospostmusings":
 					add NumberListVarValue entry to velospostmusings;
-			debug at level 6 say "DEBUG -> [x]: Added '[NumberListVarValue entry]' to NumberList [NumberListName].";
+			if debug is at level 6:
+				say "DEBUG -> [x]: Added '[NumberListVarValue entry]' to NumberList [NumberListName].";
 	else:
 		say "No NumberList Save File Found!";
 

--- a/Core Mechanics/Story Skipper Loose Variables.i7x
+++ b/Core Mechanics/Story Skipper Loose Variables.i7x
@@ -57,8 +57,7 @@ to VariableSave:
 	repeat with x running from 1 to the number of filled rows in the Table of GameVariableIDs:
 		choose row x in the Table of GameVariableIDs;
 		now CurrentVariableName is Name entry;
-		if debugactive is 1:
-			say "Stashing variable [CurrentVariableName].";
+		debug at level 6 say "Stashing variable [CurrentVariableName].";
 		if Type Entry is "text":
 			TextVariableSave;
 		else if Type Entry is "number":
@@ -72,28 +71,22 @@ to VariableSave:
 		else if Type Entry is "list of numbers":
 			NumberListVariableSave;
 	write File of TextSave from the Table of GameTexts; [freshly made table gets saved to file]
-	if debugactive is 1:
-		say "TextSave File Written.";
+	debug at level 6 say "TextSave File Written.";
 	blank out the whole of Table of GameTexts; [empty out all old data]
 	write File of NumberSave from the Table of GameNumbers; [freshly made table gets saved to file]
-	if debugactive is 1:
-		say "NumberSave File Written.";
+	debug at level 6 say "NumberSave File Written.";
 	blank out the whole of Table of GameNumbers; [empty out all old data]
 	write File of TruthSave from the Table of GameTruths; [freshly made table gets saved to file]
-	if debugactive is 1:
-		say "TruthSave File Written.";
+	debug at level 6 say "TruthSave File Written.";
 	blank out the whole of Table of GameTruths; [empty out all old data]
 	write File of IndexedTextSave from the Table of GameIndexedTexts; [freshly made table gets saved to file]
-	if debugactive is 1:
-		say "IndexedTextSave File Written.";
+	debug at level 6 say "IndexedTextSave File Written.";
 	blank out the whole of Table of GameIndexedTexts; [empty out all old data]
 	write File of TextListSave from the Table of GameTextLists; [freshly made table gets saved to file]
-	if debugactive is 1:
-		say "TextListSave File Written.";
+	debug at level 6 say "TextListSave File Written.";
 	blank out the whole of Table of GameTextLists; [empty out all old data]
 	write File of NumberListSave from the Table of GameNumberLists; [freshly made table gets saved to file]
-	if debugactive is 1:
-		say "NumberListSave File Written.";
+	debug at level 6 say "NumberListSave File Written.";
 	blank out the whole of Table of GameNumberLists; [empty out all old data]
 
 to TextVariableSave:
@@ -3774,8 +3767,7 @@ to VariableTextLoad:
 		read File of TextSave into the Table of GameTexts;
 		repeat with x running from 1 to the number of filled rows in the Table of GameTexts:
 			choose row x in the Table of GameTexts;
-			if debugactive is 1:
-				say "Restoring text [TextVarName entry].";
+			debug at level 6 say "Restoring text [TextVarName entry].";
 			if TextVarName entry is:
 				-- "PronounChoice":
 					now PronounChoice of Player is TextVarValue entry;
@@ -4003,8 +3995,7 @@ to VariableTextLoad:
 					now wrtail is TextVarValue entry;
 				-- "wrTailName":
 					now wrTailName is TextVarValue entry;
-			if debugactive is 1:
-				say "DEBUG -> VarName '[TextVarName entry]' restored to '[TextVarValue entry]'.";
+			debug at level 6 say "DEBUG -> VarName '[TextVarName entry]' restored to '[TextVarValue entry]'.";
 	else:
 		say "No Text Save File Found!";
 
@@ -4014,8 +4005,7 @@ to VariableNumberLoad:
 		read File of NumberSave into the Table of GameNumbers;
 		repeat with x running from 1 to the number of filled rows in the Table of GameNumbers:
 			choose row x in the Table of GameNumbers;
-			if debugactive is 1:
-				say "Restoring Number [NumberVarName entry].";
+			debug at level 6 say "Restoring Number [NumberVarName entry].";
 			if NumberVarName entry is:
 				-- "featgained":
 					now featgained of Player is numberVarValue entry;
@@ -6669,8 +6659,7 @@ to VariableNumberLoad:
 					now zigseat is numberVarValue entry;
 				-- "zpc_Zc":
 					now zpc_Zc is numberVarValue entry;
-			if debugactive is 1:
-				say "DEBUG -> VarName '[NumberVarName entry]' restored to '[NumberVarValue entry]'.";
+			debug at level 6 say "DEBUG -> VarName '[NumberVarName entry]' restored to '[NumberVarValue entry]'.";
 	else:
 		say "No Number Save File Found!";
 
@@ -6680,8 +6669,7 @@ to VariableTruthLoad:
 		read File of TruthSave into the Table of GameTruths;
 		repeat with x running from 1 to the number of filled rows in the Table of GameTruths:
 			choose row x in the Table of GameTruths;
-			if debugactive is 1:
-				say "Restoring Truth [TruthVarName entry].";
+			debug at level 6 say "Restoring Truth [TruthVarName entry].";
 			if TruthVarName entry is:
 				-- "A_Candy":
 					now A_Candy is TruthVarValue entry;
@@ -7343,8 +7331,7 @@ to VariableTruthLoad:
 					now zigorhadiyaquest is TruthVarValue entry;
 				-- "zpc_inzone":
 					now zpc_inzone is TruthVarValue entry;
-			if debugactive is 1:
-				say "DEBUG -> VarName '[TruthVarName entry]' restored to '[TruthVarValue entry]'.";
+			debug at level 6 say "DEBUG -> VarName '[TruthVarName entry]' restored to '[TruthVarValue entry]'.";
 	else:
 		say "No Truth Save File Found!";
 
@@ -7354,8 +7341,7 @@ to VariableIndexedTextLoad:
 		read File of IndexedTextSave into the Table of GameIndexedTexts;
 		repeat with x running from 1 to the number of filled rows in the Table of GameIndexedTexts:
 			choose row x in the Table of GameIndexedTexts;
-			if debugactive is 1:
-				say "Restoring IndexedText [IndexedTextVarName entry].";
+			debug at level 6 say "Restoring IndexedText [IndexedTextVarName entry].";
 			if IndexedTextVarName entry is:
 				-- "bcupsize":
 					now bcupsize is IndexedTextVarValue entry;
@@ -7363,8 +7349,7 @@ to VariableIndexedTextLoad:
 					now bmagic is IndexedTextVarValue entry;
 				-- "cupsize":
 					now cupsize is IndexedTextVarValue entry;
-			if debugactive is 1:
-				say "DEBUG -> VarName '[IndexedTextVarName entry]' restored to '[IndexedTextVarValue entry]'.";
+			debug at level 6 say "DEBUG -> VarName '[IndexedTextVarName entry]' restored to '[IndexedTextVarValue entry]'.";
 	else:
 		say "No IndexedText Save File Found!";
 
@@ -7394,8 +7379,7 @@ to VariableTextListLoad:
 					add TextListVarValue entry to lbcompList;
 				-- "ndmlist":
 					add TextListVarValue entry to ndmList;
-			if debugactive is 1:
-				say "DEBUG -> [x]: Added '[TextListVarValue entry]' to TextList [TextListName].";
+			debug at level 6 say "DEBUG -> [x]: Added '[TextListVarValue entry]' to TextList [TextListName].";
 	else:
 		say "No TextList Save File Found!";
 
@@ -7437,8 +7421,7 @@ to VariableNumberListLoad:
 					add NumberListVarValue entry to pfpcList;
 				-- "velospostmusings":
 					add NumberListVarValue entry to velospostmusings;
-			if debugactive is 1:
-				say "DEBUG -> [x]: Added '[NumberListVarValue entry]' to NumberList [NumberListName].";
+			debug at level 6 say "DEBUG -> [x]: Added '[NumberListVarValue entry]' to NumberList [NumberListName].";
 	else:
 		say "No NumberList Save File Found!";
 

--- a/Core Mechanics/Story Skipper.i7x
+++ b/Core Mechanics/Story Skipper.i7x
@@ -147,7 +147,8 @@ to EventSave:
 		now SituationArea entry is sarea of x;
 	write File of EventSave from the Table of GameEvents; [freshly made table gets saved to file]
 	blank out the whole of Table of GameEvents; [empty it after saving]
-	debug at level 6 say "DEBUG -> File of EventSave written.[line break]";
+	if debug is at level 6:
+		say "DEBUG -> File of EventSave written.[line break]";
 
 to EventRestore:
 	if the File of EventSave exists:
@@ -171,9 +172,11 @@ to EventRestore:
 				[bugfix code after re-naming Midway to Fair]
 				if sarea of EventObject is "Midway":
 					now sarea of EventObject is "Fair";
-				debug at level 6 say "DEBUG -> [x]: EventIdName: [EventIdName] found and set to: [ResolveState entry], [ActiveState entry], Resolution: [Resolution entry]";
+				if debug is at level 6:
+					say "DEBUG -> [x]: EventIdName: [EventIdName] found and set to: [ResolveState entry], [ActiveState entry], Resolution: [Resolution entry]";
 			else:
-				debug at level 6 say "DEBUG -> [x]: EventIdName: [EventIdName] not found in Table of GameEventIDs!";
+				if debug is at level 6:
+					say "DEBUG -> [x]: EventIdName: [EventIdName] not found in Table of GameEventIDs!";
 	else:
 		say "No Event Save File Found!";
 	blank out the whole of Table of GameEvents; [empty it after restoring]
@@ -208,7 +211,8 @@ to RoomSave:
 	write File of RoomInventorySave from the Table of GameRoomInventories; [freshly made table gets saved to file]
 	blank out the whole of Table of GameRooms; [empty after saving]
 	blank out the whole of Table of GameRoomInventories; [empty after saving]
-	debug at level 6 say "DEBUG -> File of RoomSave written.[line break]";
+	if debug is at level 6:
+		say "DEBUG -> File of RoomSave written.[line break]";
 
 to RoomRestore:
 	if the File of RoomSave exists:
@@ -231,9 +235,11 @@ to RoomRestore:
 					now RoomObject is sleepsafe;
 				else:
 					now RoomObject is not sleepsafe;
-				debug at level 6 say "DEBUG -> [x]: RoomIdName: [RoomIdName] found and set to: [Reachability entry]; [ExplorationStatus entry]; [RestSafety entry]";
+				if debug is at level 6:
+					say "DEBUG -> [x]: RoomIdName: [RoomIdName] found and set to: [Reachability entry]; [ExplorationStatus entry]; [RestSafety entry]";
 			else:
-				debug at level 6 say "DEBUG -> [x]: RoomIdName: [RoomIdName] not found in Table of GameRoomIDs!";
+				if debug is at level 6:
+					say "DEBUG -> [x]: RoomIdName: [RoomIdName] not found in Table of GameRoomIDs!";
 	if the File of RoomInventorySave exists:
 		repeat with x running through rooms:
 			truncate Invent of x to 0 entries; [cleaning out the old data]
@@ -246,7 +252,8 @@ to RoomRestore:
 				let RoomObject be the object corresponding to a name of RoomIdName in the Table of GameRoomIDs;
 				add ItemName entry to Invent of RoomObject;
 			else:
-				debug at level 6 say "DEBUG -> [x]: RoomIdName: [RoomIdName] not found in Table of GameRoomIDs!";
+				if debug is at level 6:
+					say "DEBUG -> [x]: RoomIdName: [RoomIdName] not found in Table of GameRoomIDs!";
 	else:
 		say "No Room Save File Found!";
 	blank out the whole of Table of GameRooms; [empty out all old data]
@@ -280,7 +287,8 @@ to PossessionSave:
 			now CurseStatus entry is PossesssionCursed;
 	write File of PossessionSave from the Table of GamePossessions; [freshly made table gets saved to file]
 	blank out the whole of Table of GamePossessions; [empty after saving to file]
-	debug at level 6 say "DEBUG -> File of PossessionSave written.[line break]";
+	if debug is at level 6:
+		say "DEBUG -> File of PossessionSave written.[line break]";
 
 to PossessionRestore:
 	if the File of PossessionSave exists:
@@ -302,9 +310,11 @@ to PossessionRestore:
 						now PossessionObject is cursed;
 					else:
 						now PossessionObject is not cursed;
-				debug at level 6 say "DEBUG -> [x]: PossessionIdName: [PossessionIdName] found and set to: [carried of PossessionObject] carried and [stashed of PossessionObject] stored.";
+				if debug is at level 6:
+					say "DEBUG -> [x]: PossessionIdName: [PossessionIdName] found and set to: [carried of PossessionObject] carried and [stashed of PossessionObject] stored.";
 			else:
-				debug at level 6 say "DEBUG -> [x]: PossessionIdName: [PossessionIdName] not found in Table of Game Objects!";
+				if debug is at level 6:
+					say "DEBUG -> [x]: PossessionIdName: [PossessionIdName] not found in Table of Game Objects!";
 	else:
 		say "No Possession Save File Found!";
 	blank out the whole of Table of GamePossessions; [empty out all old data]
@@ -421,10 +431,12 @@ to CharacterRestore:
 			if there is a name of CharacterIdName in the Table of GameCharacterIDs:
 				let CharacterObject be the object corresponding to a name of CharacterIdName in the Table of GameCharacterIDs;
 				if CharacterIdName is listed in PetList:
-					debug at level 6 say "DEBUG -> Pets are part of the player, thus they don't get moved.[line break]";
+					if debug is at level 6:
+						say "DEBUG -> Pets are part of the player, thus they don't get moved.[line break]";
 				[
 				else if CharacterIdName is "yourself":
-					debug at level 6 say "DEBUG -> The player doesn't get moved.[line break]";
+					if debug is at level 6:
+						say "DEBUG -> The player doesn't get moved.[line break]";
 				]
 				else if there is a name of LocationName entry in the Table of GameRoomIDs:
 					let TargetRoom be the object corresponding to a name of LocationName entry in the Table of GameRoomIDs;
@@ -502,9 +514,11 @@ to CharacterRestore:
 				now SexuallyExperienced of CharacterObject is SexuallyExperienced entry;
 				now TwistedCapacity of CharacterObject is TwistedCapacity entry;
 				now Sterile of CharacterObject is Sterile entry;
-				debug at level 6 say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] found and values restored.";
+				if debug is at level 6:
+					say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] found and values restored.";
 			else:
-				debug at level 6 say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] not found in Table of GameCharacterIDs!";
+				if debug is at level 6:
+					say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] not found in Table of GameCharacterIDs!";
 	else if the File of CharacterSave exists:
 		say "Restoring Characters...";
 		read File of CharacterSave into the Table of GameCharacters;
@@ -514,10 +528,12 @@ to CharacterRestore:
 			if there is a name of CharacterIdName in the Table of GameCharacterIDs:
 				let CharacterObject be the object corresponding to a name of CharacterIdName in the Table of GameCharacterIDs;
 				if CharacterIdName is listed in PetList:
-					debug at level 6 say "DEBUG -> Pets are part of the player, thus they don't get moved.[line break]";
+					if debug is at level 6:
+						say "DEBUG -> Pets are part of the player, thus they don't get moved.[line break]";
 				[
 				else if CharacterIdName is "yourself":
-					debug at level 6 say "DEBUG -> The player doesn't get moved.[line break]";
+					if debug is at level 6:
+						say "DEBUG -> The player doesn't get moved.[line break]";
 				]
 				else if there is a name of LocationName entry in the Table of GameRoomIDs:
 					let TargetRoom be the object corresponding to a name of LocationName entry in the Table of GameRoomIDs;
@@ -563,9 +579,11 @@ to CharacterRestore:
 				now OralVirgin of CharacterObject is OralVirgin entry;
 				now Virgin of CharacterObject is Virgin entry;
 				now AnalVirgin of CharacterObject is AnalVirgin entry;
-				debug at level 6 say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] found and values restored.";
+				if debug is at level 6:
+					say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] found and values restored.";
 			else:
-				debug at level 6 say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] not found in Table of GameCharacterIDs!";
+				if debug is at level 6:
+					say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] not found in Table of GameCharacterIDs!";
 	else:
 		say "No Character Save File Found!";
 	blank out the whole of Table of GameCharacters; [empty out all old data]
@@ -590,7 +608,8 @@ to TraitRestore:
 					add TraitText entry to Traits of CharacterObject;
 					if TraitText entry is "Tamed": [pets]
 						now CharacterObject is tamed;
-					debug at level 6 say "DEBUG -> [x]: Added Trait: '[TraitText entry]' to [TraitOwner].";
+					if debug is at level 6:
+						say "DEBUG -> [x]: Added Trait: '[TraitText entry]' to [TraitOwner].";
 	else:
 		say "No Trait Save File Found!";
 
@@ -667,9 +686,11 @@ to PlayerSave:
 			now ListName entry is "BlockList";
 			now EntryText entry is entry y of BlockList of Player;
 	write File of PlayerSave from the Table of PlayerData; [freshly made table gets saved to file]
-	debug at level 6 say "DEBUG -> File of PlayerSave written.[line break]";
+	if debug is at level 6:
+		say "DEBUG -> File of PlayerSave written.[line break]";
 	write File of PlayerListsSave from the Table of PlayerLists; [freshly made table gets saved to file]
-	debug at level 6 say "DEBUG -> File of PlayerListsSave written.[line break]";
+	if debug is at level 6:
+		say "DEBUG -> File of PlayerListsSave written.[line break]";
 	blank out the whole of Table of PlayerData; [empty after saving]
 	blank out the whole of Table of PlayerLists; [empty after saving]
 	if NewTypeInfectionActive is true: [new parts also active]
@@ -753,7 +774,8 @@ to PlayerSave:
 		now HermInterest entry is HermInterest of Player;
 		write File of NewPlayerSave from the Table of NewPlayerData; [freshly made table gets saved to file]
 		blank out the whole of Table of NewPlayerData; [empty after saving]
-		debug at level 6 say "DEBUG -> File of NewPlayerSave written.[line break]";
+		if debug is at level 6:
+			say "DEBUG -> File of NewPlayerSave written.[line break]";
 
 
 to PlayerRestore:
@@ -783,7 +805,8 @@ to PlayerRestore:
 		now Short Breast Size Desc of Player is Short Breast Size Desc entry;
 		now bodydesc of Player is bodydesc entry;
 		now bodytype of Player is bodytype entry;
-		debug at level 6 say "DEBUG -> Player Data restored.";
+		if debug is at level 6:
+			say "DEBUG -> Player Data restored.";
 	else:
 		say "No Player Save File Found!";
 	blank out the whole of Table of PlayerData; [empty out all old data]
@@ -902,7 +925,8 @@ to PlayerRestore:
 		now FemaleInterest of Player is FemaleInterest entry;
 		now TransFemaleInterest of Player is TransFemaleInterest entry;
 		now HermInterest of Player is HermInterest entry;
-		debug at level 6 say "DEBUG -> New Player Data restored.";
+		if debug is at level 6:
+			say "DEBUG -> New Player Data restored.";
 	else if NewTypeInfectionActive is true:
 		say "No Additional Player Data Save File Found!";
 	blank out the whole of Table of NewPlayerData; [empty out all old data]
@@ -931,7 +955,8 @@ to ChildrenSave:
 	now AssSpeciesName entry is AssSpeciesName of Child;
 	now TailSpeciesName entry is TailSpeciesName of Child;
 	write File of UnbornChildSave from the Table of ChildData;
-	debug at level 6 say "DEBUG -> File of UnbornChildrenSave written.[line break]";
+	if debug is at level 6:
+		say "DEBUG -> File of UnbornChildrenSave written.[line break]";
 	say "Saving born children...";
 	write File of ChildrenSave from the Table of PlayerChildren;
 	write File of ChildrenBunkerSave from the Table of PlayerBunkerChildren;
@@ -945,7 +970,8 @@ to ChildrenRestore:
 	if the File of UnbornChildSave exists:
 		say "Restoring unborn children...";
 		read File of UnbornChildSave into the Table of ChildData;
-		debug at level 6 say "DEBUG -> Unborn children restored from FSUnbornChildSave.[line break]";
+		if debug is at level 6:
+			say "DEBUG -> Unborn children restored from FSUnbornChildSave.[line break]";
 		choose row 1 in the Table of ChildData;
 		now Gestation of Child is Gestation entry;
 		now bodySpeciesName of Child is bodySpeciesName entry;
@@ -972,19 +998,22 @@ to ChildrenRestore:
 	if the File of ChildrenSave exists:
 		say "Restoring born children...";
 		read File of ChildrenSave into the Table of PlayerChildren;
-		debug at level 6 say "DEBUG -> Children restored from FSPlayerChildrenSave.[line break]";
+		if debug is at level 6:
+			say "DEBUG -> Children restored from FSPlayerChildrenSave.[line break]";
 	else:
 		say "No Children Save File Found!";
 	if the File of ChildrenBunkerSave exists:
 		say "Restoring Children (Bunker)...";
 		read File of ChildrenBunkerSave into the Table of PlayerBunkerChildren;
-		debug at level 6 say "DEBUG -> Children restored from FSPlayerChildrenBunkerSave.[line break]";
+		if debug is at level 6:
+			say "DEBUG -> Children restored from FSPlayerChildrenBunkerSave.[line break]";
 	else:
 		say "No Children (Bunker) Save File Found!";
 	if the File of ChildrenRoamingSave exists:
 		say "Restoring Children (Roaming)...";
 		read File of ChildrenRoamingSave into the Table of PlayerRoamingChildren;
-		debug at level 6 say "DEBUG -> Children restored from FSPlayerChildrenRoamingSave.[line break]";
+		if debug is at level 6:
+			say "DEBUG -> Children restored from FSPlayerChildrenRoamingSave.[line break]";
 	else:
 		say "No Children (Roaming) Save File Found!";
 
@@ -1006,7 +1035,8 @@ to BeastSave:
 		now sex entry is BeastSex;
 	write File of BeastSave from the Table of GameBeasts; [freshly made table gets saved to file]
 	blank out the whole of Table of GameBeasts; [empty after saving]
-	debug at level 6 say "DEBUG -> File of BeastSave written.[line break]";
+	if debug is at level 6:
+		say "DEBUG -> File of BeastSave written.[line break]";
 
 to BeastRestore:
 	if the File of BeastSave exists:
@@ -1025,9 +1055,11 @@ to BeastRestore:
 					now Area entry is "Fair";
 				now non-infectious entry is BeastNonInfect;
 				now sex entry is BeastSex;
-				debug at level 6 say "DEBUG -> [x]: BeastName: [BeastName] Area entry set to [BeastArea]!";
+				if debug is at level 6:
+					say "DEBUG -> [x]: BeastName: [BeastName] Area entry set to [BeastArea]!";
 			else:
-				debug at level 6 say "DEBUG -> BeastName: [BeastName] not found in Table of Random Critters!";
+				if debug is at level 6:
+					say "DEBUG -> BeastName: [BeastName] not found in Table of Random Critters!";
 	else:
 		say "No Beast Save File Found!";
 	blank out the whole of Table of GameBeasts; [empty out all old data]
@@ -1035,13 +1067,15 @@ to BeastRestore:
 to NoteSave:
 	say "Saving Notes...";
 	write File of NoteSave from the Table of JournalNotes;
-	debug at level 6 say "DEBUG -> File of NoteSave written.[line break]";
+	if debug is at level 6:
+		say "DEBUG -> File of NoteSave written.[line break]";
 
 to NoteRestore:
 	if the File of NoteSave exists:
 		say "Restoring Notes...";
 		read File of NoteSave into the Table of JournalNotes;
-		debug at level 6 say "DEBUG -> Notes restored from FSNoteSave.[line break]";
+		if debug is at level 6:
+			say "DEBUG -> Notes restored from FSNoteSave.[line break]";
 	else:
 		say "No Note Save File Found!";
 

--- a/Core Mechanics/Story Skipper.i7x
+++ b/Core Mechanics/Story Skipper.i7x
@@ -147,8 +147,7 @@ to EventSave:
 		now SituationArea entry is sarea of x;
 	write File of EventSave from the Table of GameEvents; [freshly made table gets saved to file]
 	blank out the whole of Table of GameEvents; [empty it after saving]
-	if debugactive is 1:
-		say "DEBUG -> File of EventSave written.[line break]";
+	debug at level 6 say "DEBUG -> File of EventSave written.[line break]";
 
 to EventRestore:
 	if the File of EventSave exists:
@@ -172,11 +171,9 @@ to EventRestore:
 				[bugfix code after re-naming Midway to Fair]
 				if sarea of EventObject is "Midway":
 					now sarea of EventObject is "Fair";
-				if debugactive is 1:
-					say "DEBUG -> [x]: EventIdName: [EventIdName] found and set to: [ResolveState entry], [ActiveState entry], Resolution: [Resolution entry]";
+				debug at level 6 say "DEBUG -> [x]: EventIdName: [EventIdName] found and set to: [ResolveState entry], [ActiveState entry], Resolution: [Resolution entry]";
 			else:
-				if debugactive is 1:
-					say "DEBUG -> [x]: EventIdName: [EventIdName] not found in Table of GameEventIDs!";
+				debug at level 6 say "DEBUG -> [x]: EventIdName: [EventIdName] not found in Table of GameEventIDs!";
 	else:
 		say "No Event Save File Found!";
 	blank out the whole of Table of GameEvents; [empty it after restoring]
@@ -211,8 +208,7 @@ to RoomSave:
 	write File of RoomInventorySave from the Table of GameRoomInventories; [freshly made table gets saved to file]
 	blank out the whole of Table of GameRooms; [empty after saving]
 	blank out the whole of Table of GameRoomInventories; [empty after saving]
-	if debugactive is 1:
-		say "DEBUG -> File of RoomSave written.[line break]";
+	debug at level 6 say "DEBUG -> File of RoomSave written.[line break]";
 
 to RoomRestore:
 	if the File of RoomSave exists:
@@ -235,11 +231,9 @@ to RoomRestore:
 					now RoomObject is sleepsafe;
 				else:
 					now RoomObject is not sleepsafe;
-				if debugactive is 1:
-					say "DEBUG -> [x]: RoomIdName: [RoomIdName] found and set to: [Reachability entry]; [ExplorationStatus entry]; [RestSafety entry]";
+				debug at level 6 say "DEBUG -> [x]: RoomIdName: [RoomIdName] found and set to: [Reachability entry]; [ExplorationStatus entry]; [RestSafety entry]";
 			else:
-				if debugactive is 1:
-					say "DEBUG -> [x]: RoomIdName: [RoomIdName] not found in Table of GameRoomIDs!";
+				debug at level 6 say "DEBUG -> [x]: RoomIdName: [RoomIdName] not found in Table of GameRoomIDs!";
 	if the File of RoomInventorySave exists:
 		repeat with x running through rooms:
 			truncate Invent of x to 0 entries; [cleaning out the old data]
@@ -252,8 +246,7 @@ to RoomRestore:
 				let RoomObject be the object corresponding to a name of RoomIdName in the Table of GameRoomIDs;
 				add ItemName entry to Invent of RoomObject;
 			else:
-				if debugactive is 1:
-					say "DEBUG -> [x]: RoomIdName: [RoomIdName] not found in Table of GameRoomIDs!";
+				debug at level 6 say "DEBUG -> [x]: RoomIdName: [RoomIdName] not found in Table of GameRoomIDs!";
 	else:
 		say "No Room Save File Found!";
 	blank out the whole of Table of GameRooms; [empty out all old data]
@@ -287,8 +280,7 @@ to PossessionSave:
 			now CurseStatus entry is PossesssionCursed;
 	write File of PossessionSave from the Table of GamePossessions; [freshly made table gets saved to file]
 	blank out the whole of Table of GamePossessions; [empty after saving to file]
-	if debugactive is 1:
-		say "DEBUG -> File of PossessionSave written.[line break]";
+	debug at level 6 say "DEBUG -> File of PossessionSave written.[line break]";
 
 to PossessionRestore:
 	if the File of PossessionSave exists:
@@ -310,11 +302,9 @@ to PossessionRestore:
 						now PossessionObject is cursed;
 					else:
 						now PossessionObject is not cursed;
-				if debugactive is 1:
-					say "DEBUG -> [x]: PossessionIdName: [PossessionIdName] found and set to: [carried of PossessionObject] carried and [stashed of PossessionObject] stored.";
+				debug at level 6 say "DEBUG -> [x]: PossessionIdName: [PossessionIdName] found and set to: [carried of PossessionObject] carried and [stashed of PossessionObject] stored.";
 			else:
-				if debugactive is 1:
-					say "DEBUG -> [x]: PossessionIdName: [PossessionIdName] not found in Table of Game Objects!";
+				debug at level 6 say "DEBUG -> [x]: PossessionIdName: [PossessionIdName] not found in Table of Game Objects!";
 	else:
 		say "No Possession Save File Found!";
 	blank out the whole of Table of GamePossessions; [empty out all old data]
@@ -417,7 +407,7 @@ to CharacterSave:
 	blank out the whole of Table of GameCharacters; [empty after saving]
 	blank out the whole of Table of GameCharacterVariables; [empty after saving]
 	blank out the whole of Table of GameTraits; [empty after saving]
-	if debugactive is 1:
+	if debug is at level 6:
 		say "DEBUG -> File of CharacterVariableSave written.[line break]";
 		say "DEBUG -> File of TraitSave written.[line break]";
 
@@ -431,12 +421,10 @@ to CharacterRestore:
 			if there is a name of CharacterIdName in the Table of GameCharacterIDs:
 				let CharacterObject be the object corresponding to a name of CharacterIdName in the Table of GameCharacterIDs;
 				if CharacterIdName is listed in PetList:
-					if debugactive is 1:
-						say "DEBUG -> Pets are part of the player, thus they don't get moved.[line break]";
+					debug at level 6 say "DEBUG -> Pets are part of the player, thus they don't get moved.[line break]";
 				[
 				else if CharacterIdName is "yourself":
-					if debugactive is 1:
-						say "DEBUG -> The player doesn't get moved.[line break]";
+					debug at level 6 say "DEBUG -> The player doesn't get moved.[line break]";
 				]
 				else if there is a name of LocationName entry in the Table of GameRoomIDs:
 					let TargetRoom be the object corresponding to a name of LocationName entry in the Table of GameRoomIDs;
@@ -514,11 +502,9 @@ to CharacterRestore:
 				now SexuallyExperienced of CharacterObject is SexuallyExperienced entry;
 				now TwistedCapacity of CharacterObject is TwistedCapacity entry;
 				now Sterile of CharacterObject is Sterile entry;
-				if debugactive is 1:
-					say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] found and values restored.";
+				debug at level 6 say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] found and values restored.";
 			else:
-				if debugactive is 1:
-					say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] not found in Table of GameCharacterIDs!";
+				debug at level 6 say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] not found in Table of GameCharacterIDs!";
 	else if the File of CharacterSave exists:
 		say "Restoring Characters...";
 		read File of CharacterSave into the Table of GameCharacters;
@@ -528,12 +514,10 @@ to CharacterRestore:
 			if there is a name of CharacterIdName in the Table of GameCharacterIDs:
 				let CharacterObject be the object corresponding to a name of CharacterIdName in the Table of GameCharacterIDs;
 				if CharacterIdName is listed in PetList:
-					if debugactive is 1:
-						say "DEBUG -> Pets are part of the player, thus they don't get moved.[line break]";
+					debug at level 6 say "DEBUG -> Pets are part of the player, thus they don't get moved.[line break]";
 				[
 				else if CharacterIdName is "yourself":
-					if debugactive is 1:
-						say "DEBUG -> The player doesn't get moved.[line break]";
+					debug at level 6 say "DEBUG -> The player doesn't get moved.[line break]";
 				]
 				else if there is a name of LocationName entry in the Table of GameRoomIDs:
 					let TargetRoom be the object corresponding to a name of LocationName entry in the Table of GameRoomIDs;
@@ -579,11 +563,9 @@ to CharacterRestore:
 				now OralVirgin of CharacterObject is OralVirgin entry;
 				now Virgin of CharacterObject is Virgin entry;
 				now AnalVirgin of CharacterObject is AnalVirgin entry;
-				if debugactive is 1:
-					say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] found and values restored.";
+				debug at level 6 say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] found and values restored.";
 			else:
-				if debugactive is 1:
-					say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] not found in Table of GameCharacterIDs!";
+				debug at level 6 say "DEBUG -> [x]: CharacterIdName: [CharacterIdName] not found in Table of GameCharacterIDs!";
 	else:
 		say "No Character Save File Found!";
 	blank out the whole of Table of GameCharacters; [empty out all old data]
@@ -608,8 +590,7 @@ to TraitRestore:
 					add TraitText entry to Traits of CharacterObject;
 					if TraitText entry is "Tamed": [pets]
 						now CharacterObject is tamed;
-					if debugactive is 1:
-						say "DEBUG -> [x]: Added Trait: '[TraitText entry]' to [TraitOwner].";
+					debug at level 6 say "DEBUG -> [x]: Added Trait: '[TraitText entry]' to [TraitOwner].";
 	else:
 		say "No Trait Save File Found!";
 
@@ -686,11 +667,9 @@ to PlayerSave:
 			now ListName entry is "BlockList";
 			now EntryText entry is entry y of BlockList of Player;
 	write File of PlayerSave from the Table of PlayerData; [freshly made table gets saved to file]
-	if debugactive is 1:
-		say "DEBUG -> File of PlayerSave written.[line break]";
+	debug at level 6 say "DEBUG -> File of PlayerSave written.[line break]";
 	write File of PlayerListsSave from the Table of PlayerLists; [freshly made table gets saved to file]
-	if debugactive is 1:
-		say "DEBUG -> File of PlayerListsSave written.[line break]";
+	debug at level 6 say "DEBUG -> File of PlayerListsSave written.[line break]";
 	blank out the whole of Table of PlayerData; [empty after saving]
 	blank out the whole of Table of PlayerLists; [empty after saving]
 	if NewTypeInfectionActive is true: [new parts also active]
@@ -774,8 +753,7 @@ to PlayerSave:
 		now HermInterest entry is HermInterest of Player;
 		write File of NewPlayerSave from the Table of NewPlayerData; [freshly made table gets saved to file]
 		blank out the whole of Table of NewPlayerData; [empty after saving]
-		if debugactive is 1:
-			say "DEBUG -> File of NewPlayerSave written.[line break]";
+		debug at level 6 say "DEBUG -> File of NewPlayerSave written.[line break]";
 
 
 to PlayerRestore:
@@ -805,8 +783,7 @@ to PlayerRestore:
 		now Short Breast Size Desc of Player is Short Breast Size Desc entry;
 		now bodydesc of Player is bodydesc entry;
 		now bodytype of Player is bodytype entry;
-		if debugactive is 1:
-			say "DEBUG -> Player Data restored.";
+		debug at level 6 say "DEBUG -> Player Data restored.";
 	else:
 		say "No Player Save File Found!";
 	blank out the whole of Table of PlayerData; [empty out all old data]
@@ -925,8 +902,7 @@ to PlayerRestore:
 		now FemaleInterest of Player is FemaleInterest entry;
 		now TransFemaleInterest of Player is TransFemaleInterest entry;
 		now HermInterest of Player is HermInterest entry;
-		if debugactive is 1:
-			say "DEBUG -> New Player Data restored.";
+		debug at level 6 say "DEBUG -> New Player Data restored.";
 	else if NewTypeInfectionActive is true:
 		say "No Additional Player Data Save File Found!";
 	blank out the whole of Table of NewPlayerData; [empty out all old data]
@@ -955,13 +931,12 @@ to ChildrenSave:
 	now AssSpeciesName entry is AssSpeciesName of Child;
 	now TailSpeciesName entry is TailSpeciesName of Child;
 	write File of UnbornChildSave from the Table of ChildData;
-	if debugactive is 1:
-		say "DEBUG -> File of UnbornChildrenSave written.[line break]";
+	debug at level 6 say "DEBUG -> File of UnbornChildrenSave written.[line break]";
 	say "Saving born children...";
 	write File of ChildrenSave from the Table of PlayerChildren;
 	write File of ChildrenBunkerSave from the Table of PlayerBunkerChildren;
 	write File of ChildrenRoamingSave from the Table of PlayerRoamingChildren;
-	if debugactive is 1:
+	if debug is at level 6:
 		say "DEBUG -> File of ChildrenSave written.[line break]";
 		say "DEBUG -> File of ChildrenBunkerSave written.[line break]";
 		say "DEBUG -> File of ChildrenRoamingSave written.[line break]";
@@ -970,8 +945,7 @@ to ChildrenRestore:
 	if the File of UnbornChildSave exists:
 		say "Restoring unborn children...";
 		read File of UnbornChildSave into the Table of ChildData;
-		if debugactive is 1:
-			say "DEBUG -> Unborn children restored from FSUnbornChildSave.[line break]";
+		debug at level 6 say "DEBUG -> Unborn children restored from FSUnbornChildSave.[line break]";
 		choose row 1 in the Table of ChildData;
 		now Gestation of Child is Gestation entry;
 		now bodySpeciesName of Child is bodySpeciesName entry;
@@ -998,22 +972,19 @@ to ChildrenRestore:
 	if the File of ChildrenSave exists:
 		say "Restoring born children...";
 		read File of ChildrenSave into the Table of PlayerChildren;
-		if debugactive is 1:
-			say "DEBUG -> Children restored from FSPlayerChildrenSave.[line break]";
+		debug at level 6 say "DEBUG -> Children restored from FSPlayerChildrenSave.[line break]";
 	else:
 		say "No Children Save File Found!";
 	if the File of ChildrenBunkerSave exists:
 		say "Restoring Children (Bunker)...";
 		read File of ChildrenBunkerSave into the Table of PlayerBunkerChildren;
-		if debugactive is 1:
-			say "DEBUG -> Children restored from FSPlayerChildrenBunkerSave.[line break]";
+		debug at level 6 say "DEBUG -> Children restored from FSPlayerChildrenBunkerSave.[line break]";
 	else:
 		say "No Children (Bunker) Save File Found!";
 	if the File of ChildrenRoamingSave exists:
 		say "Restoring Children (Roaming)...";
 		read File of ChildrenRoamingSave into the Table of PlayerRoamingChildren;
-		if debugactive is 1:
-			say "DEBUG -> Children restored from FSPlayerChildrenRoamingSave.[line break]";
+		debug at level 6 say "DEBUG -> Children restored from FSPlayerChildrenRoamingSave.[line break]";
 	else:
 		say "No Children (Roaming) Save File Found!";
 
@@ -1035,8 +1006,7 @@ to BeastSave:
 		now sex entry is BeastSex;
 	write File of BeastSave from the Table of GameBeasts; [freshly made table gets saved to file]
 	blank out the whole of Table of GameBeasts; [empty after saving]
-	if debugactive is 1:
-		say "DEBUG -> File of BeastSave written.[line break]";
+	debug at level 6 say "DEBUG -> File of BeastSave written.[line break]";
 
 to BeastRestore:
 	if the File of BeastSave exists:
@@ -1055,11 +1025,9 @@ to BeastRestore:
 					now Area entry is "Fair";
 				now non-infectious entry is BeastNonInfect;
 				now sex entry is BeastSex;
-				if debugactive is 1:
-					say "DEBUG -> [x]: BeastName: [BeastName] Area entry set to [BeastArea]!";
+				debug at level 6 say "DEBUG -> [x]: BeastName: [BeastName] Area entry set to [BeastArea]!";
 			else:
-				if debugactive is 1:
-					say "DEBUG -> BeastName: [BeastName] not found in Table of Random Critters!";
+				debug at level 6 say "DEBUG -> BeastName: [BeastName] not found in Table of Random Critters!";
 	else:
 		say "No Beast Save File Found!";
 	blank out the whole of Table of GameBeasts; [empty out all old data]
@@ -1067,15 +1035,13 @@ to BeastRestore:
 to NoteSave:
 	say "Saving Notes...";
 	write File of NoteSave from the Table of JournalNotes;
-	if debugactive is 1:
-		say "DEBUG -> File of NoteSave written.[line break]";
+	debug at level 6 say "DEBUG -> File of NoteSave written.[line break]";
 
 to NoteRestore:
 	if the File of NoteSave exists:
 		say "Restoring Notes...";
 		read File of NoteSave into the Table of JournalNotes;
-		if debugactive is 1:
-			say "DEBUG -> Notes restored from FSNoteSave.[line break]";
+		debug at level 6 say "DEBUG -> Notes restored from FSNoteSave.[line break]";
 	else:
 		say "No Note Save File Found!";
 

--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -4353,14 +4353,6 @@ to attributeinfect:		[sets the player values from the new attributes]
 	else:
 		now SleepRhythm of Player is 0; [standard]
 
-To attributeinfect (x - text):
-	repeat with y running from 1 to number of filled rows in Table of Random Critters:
-		choose row y in Table of Random Critters;
-		if Name entry exactly matches the text x, case insensitively:
-			now MonsterID is y;
-			attributeinfect;
-			break;
-
 To Vialchance (x - a text):
 	choose row MonsterID from Table of Random Critters;
 	if researchbypass is 1, continue the action;


### PR DESCRIPTION
## Debugging revamp
### Purpose
Currently debugging has no verbosity levels, so its either print every debugging or none at all. Especially when you have debugging active and want to debug importing and exporting and put a few extra lines of debugging into it you'll get flooded with loads of text walls of uninteresting debug text which tends to bury the interesting stuff. Hence why I'm introducing debug levels.

### Debug levels
#### Intro
Originally I wanted to have 5 debug levels but export/import spam showed to me, that a 6th level is needed for this so don't be confused, that I have a max verbosity level and a max+1 verbosity level.

#### Levels
The debuglevel defaults to level 1 and with the command `debuglevel x` you can set it from 1 to 6.

Level   | Description
-------:|----------------------------------------------------------------------------
**1**   | The default level. Same as `if debugactive is 1:`
**2-4** | Higher level aka more verbosity. Feel free to use any level that fits best.
**5**   | If you want to do some quick test which is not for production, this is the level for you.<br>For example: If you want to test a new function or a fix you could spill some of these into the code you're working on. Remember to remove this before filing your PRs.
**6**   | Extremely high verbosity. Currently only used for export/import progress.

In short: Use levels 1 to 4 mostly, level 5 for temporary debugging aka local testing and **avoid** using level 6 unless you're creating some permanent debugging which is creating extreme spam.

#### Usage
Use the command `debuglevel x` to set the debug level from 1 to 6. e. g.: `debuglevel 5`.

**Example 1** (Recommended usage. Taken from `Story Skipper Loose Variables.i7x`):

```inform7
if debug is at level 6:
	say "Stashing variable [CurrentVariableName].";
```

Here `[CurrentVariableName]` is only being *executed*, if the debug level is set to 6.


**Example 2** (Shorthand. Not recommended. Taken from `Story Skipper Loose Variables.i7x`):

```inform7
if there is no TextVarValue in row x of the Table of GameTexts:
	debug at level 4 say "Skipping empty text [TextVarName in row x of the Table of GameTexts].[line break]";
	next;
```

Here `[TextVarName in row x of the Table of GameTexts]` is always being executed which *may* lead to confusing and avoidable run-time errors if used in the wrong context. I've left that in as an example and since I know, that this doesn't explode ^^.

### Any questions?
Just ask me on Discord: `@Stadler#3007`.
<!--stackedit_data:
eyJoaXN0b3J5IjpbMTQzNjE5MTgzLDk5OTkyODczMywtMTEyOD
U0MTldfQ==
-->