### PR TITLE
Balancing Vore Predator

### DIFF
--- a/Core Mechanics/Alt Vore.i7x
+++ b/Core Mechanics/Alt Vore.i7x
@@ -160,7 +160,7 @@ to vorebyplayer:
 		now researchbypass is 1;
 		infect;
 		now researchbypass is 0;
-	decrease hunger of Player by ( 4 * scale entry ) + a random number between 8 and 16;
+	decrease hunger of Player by ( 4 * ( 5 + scale entry - scalevalue of Player ) ) + a random number between 8 and 16;
 	if hunger of Player < 0, now hunger of Player is 0;
 	decrease humanity of Player by 3;
 	increase vorecount by 1;

--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -4909,8 +4909,8 @@ This is the turnpass rule:
 		if number of filled rows in Table of PlayerChildren > 0 and a random chance of 1 in 2 succeeds, increase hunger of Player by 1;
 		if "Spartan Diet" is listed in feats of Player and hunger of Player > 0 and a random chance of 1 in 2 succeeds:
 			decrease hunger of Player by 1;
-	if "Vore Predator" is listed in feats of Player:
-		increase hunger of Player by a random number between 1 and 5;
+	if "Vore Predator" is listed in feats of Player and scalevalue of Player > 1:
+		increase hunger of Player by a random number between 1 and (1 + scalevalue of Player);
 		if "Spartan Diet" is listed in feats of Player and hunger of Player > 0 and a random chance of 1 in 2 succeeds:
 			decrease hunger of Player by 1;
 	if a random number from 1 to 25 > ( a random number between 1 and ( stamina of Player + 1 ) ):


### PR DESCRIPTION
### Purpose of the PR
Vore Predator seems to be balanced mostly around size 4+ creatures, like Wyverns for example. The smaller the player was the more (s)he'd regret being a Vore Predator because hunger increments didn't scale as well as eating same size monsters.
For example: If the Player is a Wyvern (Size 5) and eats a Kobold (Size 2) hunger would decrease by the same amount as if a Catgirl player eats a Kobold (Both size 2).
PS: Using the 'Automatic Survival'-cheat *might* be an option, but IMHO it should never be a requirement.

### GamePlay changes
**Vore Predator**: Hunger for smaller sized players will increase less and voring will reduce hunger based on the size difference now.

### Notes
Tested a bit as a Gildwing Kobold (Size 2) and as a Wyvern (Size 5) and it seems to work as intended. Wyverns might need to eat more but there's more than enough for them to eat.