### PR TITLE
Fetch actual FS install dir instead of hardcoded Program Files (x86)

### DIFF
--- a/sync.bat
+++ b/sync.bat
@@ -24,6 +24,12 @@ if '%errorlevel%' NEQ '0' (
     CD /D "%~dp0"
 :--------------------------------------
 
+:: Grab the installation path of FS
+for /f "usebackq tokens=3*" %%a in (`reg query "HKLM\SOFTWARE\WOW6432Node\Silver Games LLC\flexible" /v "Path"`) do (
+	set _FS_ROOT=%%a %%b
+)
+set "FS_INSTALLDIR=%_FS_ROOT%Flexible Survival\Release"
+
 echo [INFO] Starting...
 
 echo [INFO] Making symlink for .ctags in User folder
@@ -47,14 +53,14 @@ fsutil reparsepoint query "%USERPROFILE%\Documents\Inform\Projects\Flexible Surv
 mklink "%USERPROFILE%\Documents\Inform\Projects\Flexible Survival.inform\Source\story.ni" "%USERPROFILE%\Documents\Github\Flexible-Survival\Inform\story.ni"
 
 echo [INFO] Making symlink for .gblorb in Program Files folder
-fsutil reparsepoint query "%PROGRAMFILES(X86)%\Silver Games LLC\flexible\Flexible Survival\Release\Flexible Survival.gblorb" >nul && (
+fsutil reparsepoint query "%FS_INSTALLDIR%\Flexible Survival.gblorb" >nul && (
   echo [INFO]   Removing existing symlink...
-  del "%PROGRAMFILES(X86)%\Silver Games LLC\flexible\Flexible Survival\Release\Flexible Survival.gblorb"
+  del "%FS_INSTALLDIR%\Flexible Survival.gblorb"
 ) || (
   echo [INFO]   Backing up .gblorb
-  move /Y "%PROGRAMFILES(X86)%\Silver Games LLC\flexible\Flexible Survival\Release\Flexible Survival.gblorb" "%PROGRAMFILES(X86)%\Silver Games LLC\flexible\Flexible Survival\Release\Flexible Survival_old.gblorb"
+  move /Y "%FS_INSTALLDIR%\Flexible Survival.gblorb" "%FS_INSTALLDIR%\Flexible Survival_old.gblorb"
 )
-mklink "%PROGRAMFILES(X86)%\Silver Games LLC\flexible\Flexible Survival\Release\Flexible Survival.gblorb" "%USERPROFILE%\Documents\Inform\Projects\Flexible Survival.materials\Release\Flexible Survival.gblorb"
+mklink "%FS_INSTALLDIR%\Flexible Survival.gblorb" "%USERPROFILE%\Documents\Inform\Projects\Flexible Survival.materials\Release\Flexible Survival.gblorb"
 
 echo [INFO] Making Flexible Survival.materials folder in Inform folder
 mkdir "%USERPROFILE%\Documents\Inform\Projects\Flexible Survival.materials"


### PR DESCRIPTION
### Changes
sync.bat was using the hardcoded install-path of FS, which required installing FS to the default path, which is in `Program Files (x86)` which is not recommended.
Now it *tries* (and hopefully always succeeds) to get the install-path from the registry, assuming FS was installed through the `.msi`.