### PR TITLE
Building FS on the commandline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Dys/Notes.txt
 .tags
 .tags1
 .tags_swap
+myrelease.bat

--- a/release.bat
+++ b/release.bat
@@ -84,7 +84,7 @@ set "FS_INSTALLDIR=!_FS_ROOT!Flexible Survival\Release"
 :: Copies the gblorb to the FS_INSTALLDIR and adds an UTC based timestamp
 set "FS_GBLORB=Flexible Survival %DATESTAMP%-%TIMESTAMP%.gblorb"
 set "BUILD_TARGET=%FS_INSTALLDIR%\%FS_GBLORB%"
-cp "%BUILD_OUTPUT%" "%BUILD_TARGET%"
+copy /Y "%BUILD_OUTPUT%" "%BUILD_TARGET%"
 goto :eof
 
 :: --------------------------------------------

--- a/release.bat
+++ b/release.bat
@@ -35,6 +35,7 @@ set "NI_64Bit=%INFORM_BINDIR%\ni64.exe"
 
 :: Change this to the actual FS installdir, if you've installed FS elsewhere (which is recommended)
 set "FS_INSTALLDIR=C:\Program Files (x86)\Silver Games LLC\flexible\Flexible Survival\Release"
+
 set "BUILD_OUTPUT=%INFORM_FS%\Build\output.gblorb"
 
 :: Symlink story.ni

--- a/release.bat
+++ b/release.bat
@@ -37,6 +37,19 @@ set "NI_64Bit=%INFORM_BINDIR%\ni64.exe"
 set "FS_INSTALLDIR=C:\Program Files (x86)\Silver Games LLC\flexible\Flexible Survival\Release"
 set "BUILD_OUTPUT=%INFORM_FS%\Build\output.gblorb"
 
+:: Symlink story.ni
+set "INFORM_FS_SOURCE=%INFORM_FS%\Source"
+set "GITHUB_FS=%USERPROFILE%\Documents\Github\Flexible-Survival"
+echo [INFO] Making symlink for story.ni in Inform folder
+fsutil reparsepoint query "%INFORM_FS_SOURCE%\story.ni" >nul && (
+  echo [INFO]   Removing existing symlink...
+  del "%INFORM_FS_SOURCE%\story.ni"
+) || (
+  echo [INFO]   Backing up story.ni
+  move /Y "%INFORM_FS_SOURCE%\story.ni" "%INFORM_FS_SOURCE%\story_old.ni"
+)
+mklink "%INFORM_FS_SOURCE%\story.ni" "%GITHUB_FS%\Inform\story.ni"
+
 "%NI_64Bit%" -release -internal "%INFORM_INTERNAL%" -project "%INFORM_FS%" -external "%INFORM_DATADIR%" -format=ulx
 if errorlevel 1 (
 	pause

--- a/release.bat
+++ b/release.bat
@@ -1,0 +1,84 @@
+@echo off & setlocal EnableDelayedExpansion
+
+:: BatchGotAdmin
+:-------------------------------------
+REM --> Check for permissions
+>nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"
+
+REM --> If error flag set, we do not have admin.
+if errorlevel 1 (
+    echo Requesting administrative privileges...
+    goto UACPrompt
+) else ( goto gotAdmin )
+
+:UACPrompt
+    echo Set UAC = CreateObject^("Shell.Application"^) > "%temp%\getadmin.vbs"
+    echo UAC.ShellExecute "%~s0", "", "", "runas", 1 >> "%temp%\getadmin.vbs"
+
+    "%temp%\getadmin.vbs"
+    exit /B
+
+:gotAdmin
+    if exist "%temp%\getadmin.vbs" ( del "%temp%\getadmin.vbs" )
+    pushd "%CD%"
+    CD /D "%~dp0"
+:--------------------------------------
+
+set "INFORM_INSTALLDIR=%ProgramFiles(x86)%\Inform 7"
+set "INFORM_BINDIR=%INFORM_INSTALLDIR%\Compilers"
+set "INFORM_INTERNAL=%INFORM_INSTALLDIR%\Internal"
+set "INFORM_DATADIR=%USERPROFILE%\Documents\Inform"
+set "INFORM_FS=%INFORM_DATADIR%\Projects\Flexible Survival.inform"
+
+:: Change this, if you've downloaded the 64 Bit ni.exe elsewhere
+set "NI_64Bit=%INFORM_BINDIR%\ni64.exe"
+
+:: Change this to the actual FS installdir, if you've installed FS elsewhere (which is recommended)
+set "FS_INSTALLDIR=C:\Program Files (x86)\Silver Games LLC\flexible\Flexible Survival\Release"
+set "BUILD_OUTPUT=%INFORM_FS%\Build\output.gblorb"
+
+"%NI_64Bit%" -release -internal "%INFORM_INTERNAL%" -project "%INFORM_FS%" -external "%INFORM_DATADIR%" -format=ulx
+if errorlevel 1 (
+	pause
+	goto :eof
+)
+
+"%INFORM_BINDIR%\inform6.exe" -w~S~DG "%INFORM_FS%\Build\auto.inf" "%INFORM_FS%\Build\output.ulx"
+"%INFORM_BINDIR%\cBlorb.exe" -windows "%INFORM_FS%\Release.blurb" "%BUILD_OUTPUT%"
+
+:: --------------------------------------------
+call :get_utc_time
+
+:: Add leading zeros
+set gmt_hour=0%gmt_hour%
+set gmt_hour=%gmt_hour:~-2%
+set gmt_minute=0%gmt_minute%
+set gmt_minute=%gmt_minute:~-2%
+set gmt_second=0%gmt_second%
+set gmt_second=%gmt_second:~-2%
+set gmt_day=0%gmt_day%
+set gmt_day=%gmt_day:~-2%
+set gmt_month=0%gmt_month%
+set gmt_month=%gmt_month:~-2%
+
+set DATESTAMP=%gmt_year%%gmt_month%%gmt_day%
+set TIMESTAMP=%gmt_hour%%gmt_minute%
+:: --------------------------------------------
+
+:: Copies the gblorb to the FS_INSTALLDIR and add an UTC based timestamp
+set "FS_GBLORB=Flexible Survival %DATESTAMP%-%TIMESTAMP%.gblorb"
+set "BUILD_TARGET=%FS_INSTALLDIR%\%FS_GBLORB%"
+cp "%BUILD_OUTPUT%" "%BUILD_TARGET%"
+goto :eof
+
+:: --------------------------------------------
+:get_utc_time
+for /f "tokens=1,2 delims==" %%G in ('wmic path Win32_UTCTime get /value ^| find "="') do (call :setUTCvars %%G %%H)
+goto :eof
+
+:setUTCvars
+set _var=%1
+set _value=%2
+set gmt_!_var!=!_value!
+goto :eof
+:: --------------------------------------------


### PR DESCRIPTION
### Purpose of the PR
Currently I can't compile with the Inform 7 IDE so I had to rely on the 64 Bit ni.exe which only works on the commandline. To make it less tedious for me and to make it useable for others I've wrote this script.

### Setup
See the Gist [Building FS on the commandline.md](https://gist.github.com/Stadler76/166ed6d455c7ad0ef8fb9e4f7843a6fc).
You may omit [Step 3. Prepare the `release.bat`](https://gist.github.com/Stadler76/166ed6d455c7ad0ef8fb9e4f7843a6fc#3-prepare-the-releasebat) there, but if you want to edit the release.bat its recommended to copy it to `myrelease.bat` beforehand (`myrelease.bat` is added to the `.gitignore`)

### Requirements
Currently it assumes that you've got the following folder structure and or (better) symlinked them (see the table below or run the sync.bat script) and installed the game through the .msi-executable.

Action | File/Folder | At
-- | -- | --
Copy the file from the folder Documents\Github\Inform | story.ni | Documents\Inform\Projects\Flexible Survival.inform\Source
Create a new folder called | Flexible Survival.materials | Documents\Inform\Projects\
Copy the folder from the folder Documents\Github | Figures | Documents\Inform\Projects\Flexible Survival.materials
Copy the folders from the folder Documents\Github | Every folder that is not Figures or Inform | Documents\Inform\Extensions

#### Notes
- Both the sync.bat and the release.bat gets the FS-installdir from the Windows registry, so you can install FS anywhere you want to.
- If you've went through step 1 through 9 of [CONTRIBUTING.md](../blob/master/CONTRIBUTING.md) you're probably good to go.

### What the script does
The first thing, the script does is to restore the symlink to `story.ni` so you don't need to copy and paste it into Inform 7 every time you make changes to it.
The script uses the 64 Bit ni.exe to compile the script and compiles the output.gblorb. Then it copies it to the FS-installdir and renames it to `Flexible Survival DATE-TIME.gblorb`. The appended timestamp is in UTC-time. e. g. `Flexible Survival 20191023-0248.gblorb`.
From there you can simply drag and drop it to the ![git.exe](https://user-images.githubusercontent.com/13157984/67438456-d58a9d00-f5f3-11e9-8623-61b174a369a4.png)
