### PR TITLE
Fixing a bunch of minor issues I stumbled upon

### DIFF
--- a/AGentlemanCalledB/Francois Infections.i7x
+++ b/AGentlemanCalledB/Francois Infections.i7x
@@ -18,12 +18,12 @@ to say CheesecakeBodyTF:
 		say "it becomes soft and malleable, just like cheesecake. You can't help but moan slightly as your form shifts, becoming plump and curvaceous, leaving you hefty and rubenesque[if Breast Size of Player > 0 and Nipple Count of Player > 0 and player is cheesecakeskinned]. You feel a sudden tightness forming around your body as a tight corset made of flaky pastry forms around you, boosting your breasts up into full view[else if Player is cheesecakeskinned]. You feel a sudden tightness forming around your body as a tight corset made of flaky pastry forms around you[end if]";
 
 Definition: a person is Cheesecakeskinned:
-if SkinName of Player is "Cheesecake", yes;
-no;
+	if Player has a skin of "Cheesecake", yes;
+	no;
 
 Definition: a person is Cheesecakebodied:
-if SkinName of Player is "Cheesecake", yes;
-no;
+	if Player has a body of "Cheesecake", yes;
+	no;
 
 Section 2 - Creature Insertion
 

--- a/Core Mechanics/Sex and Infection Functions.i7x
+++ b/Core Mechanics/Sex and Infection Functions.i7x
@@ -28,6 +28,11 @@ to decide if (x - a person) has a body of (i - a text):
 	if BodyName of x is i, decide yes;
 	decide no;
 
+[@Todo: Handle new style infection here when implemented]
+to decide if (x - a person) has a skin of (i - a text):
+	if SkinName of x is i, decide yes;
+	decide no;
+
 to decide which text is GetSpeciesName from (N - a text):
 	if N is not "" and there is a Name of N in the Table of Random Critters:
 		choose a row with Name of N in the Table of Random Critters;

--- a/Lone Wanderer/Black Pearl.i7x
+++ b/Lone Wanderer/Black Pearl.i7x
@@ -10,6 +10,7 @@ The level of Curious Pearl is 5. [minimum level to find the event]
 Curious Pearl is inactive.
 
 when play begins:
+	add Curious Pearl to BadSpots of MaleList;
 	add Curious Pearl to BadSpots of FurryList;
 	add Curious Pearl to BadSpots of FeralList;
 

--- a/Lone Wanderer/Black Pearl.i7x
+++ b/Lone Wanderer/Black Pearl.i7x
@@ -6,12 +6,12 @@ Section 0 - Event
 
 Curious Pearl is a situation.
 The sarea of Curious Pearl is "Beach".
-The level of Valuable RLD Artifact is 5. [minimum level to find the event]
+The level of Curious Pearl is 5. [minimum level to find the event]
 Curious Pearl is inactive.
 
 when play begins:
 	add Curious Pearl to BadSpots of FurryList;
-	add Valuable Warehouse Artifact to badspots of FeralList;
+	add Curious Pearl to BadSpots of FeralList;
 
 Instead of resolving Curious Pearl:
 	if KyrverthStage is 3:


### PR DESCRIPTION
### Purpose of the PR
This fixes two minor issues I've stumbled upon while working on other stuff.

### Gameplay Changes
- **Curious Pearl:** Minimum level and `BadSpots of FeralList` was applied to the wrong event (no issue, just consistency).
- **Francois Infections:** The checks, if the player is cheesecakeskinned/-bodied should work now.

### Internal changes
- Added the function `to decide if (x - a person) has a skin of (i - a text):`.

### Notes
The **Curious Pearl** event is part of the [Second Quest Chain](http://wiki.flexiblesurvival.com/w/Kyrverth#Second_Quest_Chain:) or Kyrverth and the quest chain won't even start if the level requirement is not met or if one of Ferals, Furries or Males are banned.
AFAICS you can only ban situations when starting a new game.
And I've only tested, if everything compiles without issues, which it does.