### PR TITLE
The FS-installation-dir will now be trimmed from whitespaces.

### DIFF
--- a/release.bat
+++ b/release.bat
@@ -79,7 +79,8 @@ set TIMESTAMP=%gmt_hour%%gmt_minute%
 for /f "usebackq tokens=3*" %%a in (`reg query "HKLM\SOFTWARE\WOW6432Node\Silver Games LLC\flexible" /v "Path"`) do (
 	set _FS_ROOT=%%a %%b
 )
-set "FS_INSTALLDIR=!_FS_ROOT!Flexible Survival\Release"
+call :Trim _FS_ROOT_TRIMMED !_FS_ROOT!
+set "FS_INSTALLDIR=%_FS_ROOT_TRIMMED%Flexible Survival\Release"
 
 :: Copies the gblorb to the FS_INSTALLDIR and adds an UTC based timestamp
 set "FS_GBLORB=Flexible Survival %DATESTAMP%-%TIMESTAMP%.gblorb"
@@ -96,5 +97,10 @@ goto :eof
 set _var=%1
 set _value=%2
 set gmt_!_var!=!_value!
+goto :eof
+
+:Trim
+set Params=%*
+for /f "tokens=1*" %%a in ("!Params!") do set %1=%%b
 goto :eof
 :: --------------------------------------------

--- a/sync.bat
+++ b/sync.bat
@@ -1,4 +1,4 @@
-@echo off
+@echo off & setlocal EnableDelayedExpansion
 
 :: BatchGotAdmin
 :-------------------------------------
@@ -28,7 +28,8 @@ if '%errorlevel%' NEQ '0' (
 for /f "usebackq tokens=3*" %%a in (`reg query "HKLM\SOFTWARE\WOW6432Node\Silver Games LLC\flexible" /v "Path"`) do (
 	set _FS_ROOT=%%a %%b
 )
-set "FS_INSTALLDIR=%_FS_ROOT%Flexible Survival\Release"
+call :Trim _FS_ROOT_TRIMMED !_FS_ROOT!
+set "FS_INSTALLDIR=%_FS_ROOT_TRIMMED%Flexible Survival\Release"
 
 echo [INFO] Starting...
 
@@ -89,3 +90,9 @@ for /d %%D in (*) do (
 )
 
 pause
+goto :eof
+
+:Trim
+set Params=%*
+for /f "tokens=1*" %%a in ("!Params!") do set %1=%%b
+goto :eof


### PR DESCRIPTION
### Purpose of the PR
Had an issue where the created `output.gblorb` wasn't copied because the registry-entry for the FS install dir had a trailing space in it.
Now it trims them. Thanks to `@Kurainyx#9727` for the help with hunting it down and testing the fix.
