### PR TITLE
End the story overwrite fix

### DIFF
--- a/Core Mechanics/Alt Combat.i7x
+++ b/Core Mechanics/Alt Combat.i7x
@@ -1360,25 +1360,26 @@ To lose:
 	now lastfightround is turns;
 	now lost is 1;
 	say "[victory entry][line break]";
-	if scenario is "Researcher" and ( there is no resbypass in row MonsterID of Table of Random Critters or resbypass entry is false ):
-		say "";
-	else:
-		if non-infectious entry is false:
-			if there is no Cross-Infection in row MonsterID of Table of Random Critters or Cross-Infection entry is "": [cross-infection does not exist or empty]
-				infect; [regular infect]
-			else: [Cross-Infection found]
-				if there is a name of Cross-Infection entry in the Table of Random Critters:
-					if the BannedStatus corresponding to the name of Cross-Infection entry in the Table of Random Critters is true:
-						infect; [cross-infection banned -> defaulting back to regular infect]
-					else:
-						infect Cross-Infection entry; [monster's sexually transmitted infection is not the monster's own - for example Husky Bitch <-> Husky Alpha]
-				else: [cross infection not found]
-					say "ERROR! Cross-Infection [Cross-Infection entry] for the infection [name entry] not found! Please report how you saw this on the FS Discord and quote this message!";
-	choose row MonsterID from the Table of Random Critters;
-	if Libido of Player < libido entry and non-infectious entry is false:
-		increase Libido of Player by 4;
-	else:
-		increase Libido of Player by 2;
+	if the story has not ended:
+		if scenario is "Researcher" and ( there is no resbypass in row MonsterID of Table of Random Critters or resbypass entry is false ):
+			say "";
+		else:
+			if non-infectious entry is false:
+				if there is no Cross-Infection in row MonsterID of Table of Random Critters or Cross-Infection entry is "": [cross-infection does not exist or empty]
+					infect; [regular infect]
+				else: [Cross-Infection found]
+					if there is a name of Cross-Infection entry in the Table of Random Critters:
+						if the BannedStatus corresponding to the name of Cross-Infection entry in the Table of Random Critters is true:
+							infect; [cross-infection banned -> defaulting back to regular infect]
+						else:
+							infect Cross-Infection entry; [monster's sexually transmitted infection is not the monster's own - for example Husky Bitch <-> Husky Alpha]
+					else: [cross infection not found]
+						say "ERROR! Cross-Infection [Cross-Infection entry] for the infection [name entry] not found! Please report how you saw this on the FS Discord and quote this message!";
+		choose row MonsterID from the Table of Random Critters;
+		if Libido of Player < libido entry and non-infectious entry is false:
+			increase Libido of Player by 4;
+		else:
+			increase Libido of Player by 2;
 	if the player is not lonely:
 		now lastfight of companion of Player is turns;
 	if HP of Player < 1, now HP of Player is 1;

--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -4784,6 +4784,9 @@ postimport rules is a rulebook.
 Everyturn rules is a rulebook.
 
 This is the turnpass rule:
+	if the story has ended:
+		follow the everyturn rules;
+		rule succeeds;
 	follow the cock descr rule;
 	if "Sanity Saver" is listed in the feats of Player:
 		now humanity of Player is 100;

--- a/Inform/story.ni
+++ b/Inform/story.ni
@@ -4784,6 +4784,10 @@ postimport rules is a rulebook.
 Everyturn rules is a rulebook.
 
 This is the turnpass rule:
+	now fightstatus is 0;
+	now looknow is 0;
+	now ishunting is false;
+	now showlocale is true;
 	if the story has ended:
 		follow the everyturn rules;
 		rule succeeds;
@@ -4792,10 +4796,6 @@ This is the turnpass rule:
 		now humanity of Player is 100;
 	follow the cunt descr rule;
 	follow the breast descr rule;
-	now fightstatus is 0;
-	now looknow is 0;
-	now ishunting is false;
-	now showlocale is true;
 	if HP of Velos > 2:
 		if Velos is not in the location of the player:		[traveling w/player]
 			now Velos is in the location of the player;
@@ -4912,8 +4912,8 @@ This is the turnpass rule:
 		if number of filled rows in Table of PlayerChildren > 0 and a random chance of 1 in 2 succeeds, increase hunger of Player by 1;
 		if "Spartan Diet" is listed in feats of Player and hunger of Player > 0 and a random chance of 1 in 2 succeeds:
 			decrease hunger of Player by 1;
-	if "Vore Predator" is listed in feats of Player:
-		increase hunger of Player by a random number between 1 and 5;
+	if Player can vore and scalevalue of Player > 1:
+		increase hunger of Player by a random number between 1 and (1 + scalevalue of Player);
 		if "Spartan Diet" is listed in feats of Player and hunger of Player > 0 and a random chance of 1 in 2 succeeds:
 			decrease hunger of Player by 1;
 	if a random number from 1 to 25 > ( a random number between 1 and ( stamina of Player + 1 ) ):


### PR DESCRIPTION
### Purpose of the PR
Proposed fix for overwriting the `end the story saying "..."` text and that some endings were skipped.

### Gameplay changes
**Game Over:** A couple game overs (e. g. Lucifer's Mare) weren't always playing properly and the text displaying the game over reason, like **\*\*\* You became a Wyvern's meal! \*\*\*** was overwritten occacionally. This should be fixed now.

### Internal changes
If the player had a game over after losing a battle he/she would still get `infect;`ed which might overwrite the `BodyName of Player` in addition to that the `turnpass rule` will now mostly be skipped.
A change to vore predator was accidentally reverted in `story.ni`. Re-reverted that :-)

### Note
Did the usual brief tests and a couple more of them in my work on game endings. I've also looked though `This is the turnpass rule:` from top to bottom to make sure, that skipping it doesn't break anything post-game over. It shouldn't.