### PR TITLE
Fix dolphinlist list from crashing game

### DIFF
--- a/Stripes/Bouncy Castle.i7x
+++ b/Stripes/Bouncy Castle.i7x
@@ -39,7 +39,7 @@ the sarea of Snared Vixen is "Beach".
 when play begins:
 	add Snared Vixen to BadSpots of FemaleList; [We may want to add an event later to allow people with 'girl' banned access to the Bouncy Castle]
 	add Snared Vixen to BadSpots of FurryList;
-	now Dolphinlist is { "C", "A", "X", "B", "X", "C", "A", "D", "X", "C", "X", "A" }; [Creates a list of letters that are pulled for later events]
+	now dolphinlist is { "C", "A", "X", "B", "X", "C", "A", "D", "X", "C", "X", "A" }; [Creates a list of letters that are pulled for later events]
 	let templist be { "A", "C", "D", "E"}; [Prepares additional events to add to dolphinlist]
 	sort templist in random order; [Sets these extra events to slots 3, 5, 9, and 11 for a quasi-random search]
 	now entry 3 of dolphinlist is entry 1 of tempList;


### PR DESCRIPTION
Using `check dolphin X` crashes the current version of the game due to attempting to access an empty list. This appears to be due to a change accidentally uppercasing the definition update here. (Unfamiliar with this engine, but this is my best guess!)

Submitting directly since this appears to be a quick fix, happy to test more in-depth w/ full setup if not!