### PR TITLE
Katherine Bug Fix

### DIFF
--- a/Kirov/German Shepherd Bitch.i7x
+++ b/Kirov/German Shepherd Bitch.i7x
@@ -39,7 +39,7 @@ to say gsbDescription:
 			now gsbKatherine is true;
 		else:
 			now gsbKatherine is false;
-			if a random chance of 1 in 3 succeeds:
+			if HP of Katherine is 0 and a random chance of 1 in 3 succeeds:
 				now HP of Katherine is 1;
 		if gsbKatherine is true:
 			[ The player is encountering Katherine ]

--- a/Kirov/Katherine.i7x
+++ b/Kirov/Katherine.i7x
@@ -86,6 +86,10 @@ XP of Katherine is 0.
 Level of Katherine is 0.
 Armor of Katherine is 0.
 
+a postimport rule: [bugfixing rules for players that import savegames]
+	if HP of Katherine < 2 and Katherine is in Makeshift Rec Room:
+		now HP of Katherine is 2;
+
 Section 1 - Discussion
 
 to say KatherineTalkMenu:


### PR DESCRIPTION
Fix for a bug which caused Katherine's HP to be reset to 1 (pre-recruitment) after she had been recruited (HP 2 or greater). A postimport rule was also added to reset Katherine to a proper state in cases where this bug has manifested.