### PR TITLE
Extra Synonyms for Jerking Off

### DIFF
--- a/Core Mechanics/Milking.i7x
+++ b/Core Mechanics/Milking.i7x
@@ -96,8 +96,7 @@ Carry out PlayerBreastMilking:
 			say "You milk your own breasts, providing relief from their fullness.";
 
 PlayerCockmilking is an action applying to nothing.
-understand "jerkoff" as PlayerCockmilking.
-understand "jerk off" as PlayerCockmilking.
+understand "jerkoff","jerk off","beatoff","beat off","whackoff","whack off","wankoff","wank off","wank","pawoff","paw off","fap","beat my meat","choke the chicken" as PlayerCockmilking.
 lastCockMilking is a number that varies. [@Tag:NotSaved] lastCockMilking is usually 500.
 
 check PlayerCockmilking:


### PR DESCRIPTION
"Milking", Line 99: Added a dozen extra synonyms for the "PlayerCockmilking" action.

(Did not add "masturbate" because it would be strange for a female player character to be told they can't masturbate without a penis.)