### PR TITLE
Prevents the probability of a stat-increase occurring from being affected by how many stats are eligible for increase.

### DIFF
--- a/Core Mechanics/Alt Vore.i7x
+++ b/Core Mechanics/Alt Vore.i7x
@@ -155,31 +155,59 @@ to vorebyplayer:
 		decrease humanity of Player by 2; [Additional humanity loss]
 	else:
 		say "[vorebyplayer00]"; [Master vore scene]
-	let vv be a random number between 1 and 6;
 	let powerchance be 4;
 	if "Bestial Power" is listed in feats of Player, increase powerchance by 2;
 	if a random chance of powerchance in 20 succeeds:
-		if vv is 1:
+		let vc be 0; [ setting up which stats are valid choices for the stat increase ]
+		let vstr be -1;
+		if strength of Player < str entry and str entry >= ( 12 + level of Player ):
+			increase vc by 1;
+			now vstr is vc;
+		let vint be -1;
+		if Intelligence of Player < int entry and int entry >= ( 12 + level of Player ):
+			increase vc by 1;
+			now vint is vc;
+		let vdex be -1;
+		if dexterity of Player < dex entry and dex entry >= ( 12 + level of Player ):
+			increase vc by 1;
+			now vdex is vc;
+		let vsta be -1;
+		if stamina of Player < sta entry and sta entry >= ( 12 + level of Player ):
+			increase vc by 1;
+			now vsta is vc;
+		let vper be -1;
+		if perception of Player < per entry and per entry >= ( 12 + level of Player ):
+			increase vc by 1;
+			now vper is vc;
+		let vcha be -1;
+		if charisma of Player < cha entry and cha entry >= ( 12 + level of Player ):
+			increase vc by 1;
+			now vcha is vc;
+		[ now all numbers from 1 to vc are indicative of a stat which can be increased ]
+		let vz be 1;
+		if vc is 0, now vz is 0; [ since I don't know what happens when you ask for a random number between 1 and 0, this is here as a safety precaution ]
+		let vv be a random number between vz and vc;
+		if vv is vstr:
 			if strength of Player < str entry and str entry >= ( 12 + level of Player ):
 				say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your muscles swelling with [Name entry] [one of]strength[or]physique[or]power[at random].";
 				StatChange "Strength" by 1;
-		if vv is 2:
+		if vv is vint:
 			if Intelligence of Player < int entry and int entry >= ( 12 + level of Player ):
 				say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your mind swelling with [Name entry] [one of]intelligence[or]wit[or]complexity[at random].";
 				StatChange "Intelligence" by 1;
-		if vv is 3:
+		if vv is vdex:
 			if dexterity of Player < dex entry and dex entry >= ( 12 + level of Player ):
 				say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your hand-eye coordination improving with [Name entry] [one of]dexterity[or]physique[or]accuracy[at random].";
 				StatChange "Dexterity" by 1;
-		if vv is 4:
+		if vv is vsta:
 			if stamina of Player < sta entry and sta entry >= ( 12 + level of Player ):
 				say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your body toughening with [Name entry] [one of]stamina[or]physique[or]power[at random].";
 				StatChange "Stamina" by 1;
-		if vv is 5:
+		if vv is vper:
 			if perception of Player < per entry and per entry >= ( 12 + level of Player ):
 				say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your senses being heightened with [Name entry] [one of]perception[or]aptitude[or]feral attention[at random].";
 				StatChange "Perception" by 1;
-		if vv is 6:
+		if vv is vcha:
 			if charisma of Player < cha entry and cha entry >= ( 12 + level of Player ):
 				say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your social sense improving with [Name entry] [one of]charisma[or]natural charm[or]pheromones[at random].";
 				StatChange "Charisma" by 1;

--- a/Core Mechanics/Alt Vore.i7x
+++ b/Core Mechanics/Alt Vore.i7x
@@ -192,25 +192,20 @@ to vorebyplayer:
 				say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your muscles swelling with [Name entry] [one of]strength[or]physique[or]power[at random].";
 				StatChange "Strength" by 1;
 		if vv is vint:
-			if Intelligence of Player < int entry and int entry >= ( 12 + level of Player ):
-				say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your mind swelling with [Name entry] [one of]intelligence[or]wit[or]complexity[at random].";
-				StatChange "Intelligence" by 1;
+			say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your mind swelling with [Name entry] [one of]intelligence[or]wit[or]complexity[at random].";
+			StatChange "Intelligence" by 1;
 		if vv is vdex:
-			if dexterity of Player < dex entry and dex entry >= ( 12 + level of Player ):
-				say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your hand-eye coordination improving with [Name entry] [one of]dexterity[or]physique[or]accuracy[at random].";
-				StatChange "Dexterity" by 1;
+			say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your hand-eye coordination improving with [Name entry] [one of]dexterity[or]physique[or]accuracy[at random].";
+			StatChange "Dexterity" by 1;
 		if vv is vsta:
-			if stamina of Player < sta entry and sta entry >= ( 12 + level of Player ):
-				say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your body toughening with [Name entry] [one of]stamina[or]physique[or]power[at random].";
-				StatChange "Stamina" by 1;
+			say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your body toughening with [Name entry] [one of]stamina[or]physique[or]power[at random].";
+			StatChange "Stamina" by 1;
 		if vv is vper:
-			if perception of Player < per entry and per entry >= ( 12 + level of Player ):
-				say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your senses being heightened with [Name entry] [one of]perception[or]aptitude[or]feral attention[at random].";
-				StatChange "Perception" by 1;
+			say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your senses being heightened with [Name entry] [one of]perception[or]aptitude[or]feral attention[at random].";
+			StatChange "Perception" by 1;
 		if vv is vcha:
-			if charisma of Player < cha entry and cha entry >= ( 12 + level of Player ):
-				say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your social sense improving with [Name entry] [one of]charisma[or]natural charm[or]pheromones[at random].";
-				StatChange "Charisma" by 1;
+			say "     By consuming your foe, you have managed to absorb some of them to empower yourself. You feel your social sense improving with [Name entry] [one of]charisma[or]natural charm[or]pheromones[at random].";
+			StatChange "Charisma" by 1;
 	if "Safe Appetite" is not listed in feats of Player:
 		say "     Indulging in this monstrous act has further weakened your grip on your own humanity even as you feel the nanites from your prey flooding your system as your belly quickly seeks to consume them. Your hunger, satisfied for now, is decreased dramatically.";
 		now researchbypass is 1;


### PR DESCRIPTION
As stated above, this PR prevents the probability of a stat-increase being affected by how many stats are eligible for the increase.
Before the PR, if the stat randomly chosen isn't eligible for an increase, no stat is increase.
This PR restricts the random selection of stats only to those that are eligible for an increase.

If the original behaviour was actually intended for balance reasons, close this PR without merging.