### PR TITLE
Move initial table definition to fix build error

### DIFF
--- a/Core Mechanics/Game Endings.i7x
+++ b/Core Mechanics/Game Endings.i7x
@@ -229,7 +229,7 @@ to ratetheplayer:
 		say ".";
 	LineBreak;
 
-Table of GameEndings[ (continued)]
+Table of GameEndings (continued)
 Name (text)	Type (text)	Subtype (text)	Ending (rule)	Priority (number)	Triggered (truth state)
 "Player Starvation"	"Death"	"Starvation"	Player Starvation rule	10	false
 "Player has died"	"Death"	""	Player has died rule	10	false

--- a/Core Mechanics/GameTables.i7x
+++ b/Core Mechanics/GameTables.i7x
@@ -66,7 +66,7 @@ Table of GamePossessions
 Name(text)	CarriedNumber(number)	StoredNumber(number)	EquippedStatus(truth state)	CurseStatus(truth state)
 with 1000 blank rows
 
-Table of GameEndings (continued)
+Table of GameEndings[ (continued)]
 Name (text)	Type (text)	Subtype (text)	Ending (rule)	Priority (number)	Triggered (truth state)
 --	--	--	--	0	false
 


### PR DESCRIPTION
To fix issue #2409 

`Core Mechanics/GameTables.i7x` is included before `Core Mechanics/Game Endings.i7x` so the initial table definition should be there I think.