### PR TITLE
Fix to birth control pill while pregnant

### DIFF
--- a/Hellerhound/Control Pills.i7x
+++ b/Hellerhound/Control Pills.i7x
@@ -53,7 +53,7 @@ wassterile is a number that varies.
 to say controlpilluse:
 	increase steriletime by 24;
 	if child is not born and gestation of child > 0:
-		now child is born;
+		now child is not born; [ Fixed 2022-03-08, leave set as *not born* so player can get pregnant again ]
 		now gestation of Child is 0;
 		say "Your pregnant belly feels odd, and something slushes out of your hole, melting into mush. Looks like the pill aborted you. You feel lighter as your belly shrinks back to its original size.";
 	if inheat is True:


### PR DESCRIPTION
Fixes this bug reported:
> Can also verify the latter, tested on a character with full pism command unlocked (shows heat status) using two infections that are 'always in heat' (husky bitch and breederslut).
> 
> If using using the birth control pill when not pregnant, it changes status to sterile until the pill ends and then goes to normal status for a brief bit and then back to in heat (as is normal for the always in heat infections)
> 
> If using the birth control pill when pregnant, it changes the status to sterile until the pill ends, and then lists estrus status as normal, but does not go back to in heat as is normal for those infections, and also seems to be unable to get pregnant as well