### PR TITLE
Final updates for new walkin table

### DIFF
--- a/Qazarar/Magic Drake.i7x
+++ b/Qazarar/Magic Drake.i7x
@@ -1039,6 +1039,14 @@ instead of sniffing gilded staff:
 
 Usedesc of gilded staff is "[mdrakecontact]";
 
+Table of WalkInEvents (continued)
+Priority	Name	EventObject	EventConditions	EventRoom	LastEncounterTurn	CoolDownTurns	EncounterPercentage
+1	"Wallstuck"	Wallstuck	"[EventConditions_Wallstuck]"	Grey Abbey Library	2500	2	100
+
+to say EventConditions_Wallstuck:
+	if (mdasslevel > 3 and gilded staff is not owned):
+		now CurrentWalkinEvent_ConditionsMet is true;
+
 Table of GameEventIDs (continued)
 Object	Name
 Wallstuck	"Wallstuck"
@@ -1049,10 +1057,7 @@ The level of Wallstuck is 5.
 Sarea of Wallstuck is "Outside".
 
 [Drake Visit - gain gilded staff and leads to more content]
-instead of navigating Grey Abbey Library while (location of player is Red Light District and mdasslevel > 3 and gilded staff is not owned and a random chance of 1 in 2 succeeds):
-	say "[NavCheck Grey Abbey Library]";
-	if NavCheckReturn is false, stop the action;
-	move player to Grey Abbey Library;
+to say ResolveEvent Wallstuck:
 	say "     It all began as an otherwise normal day at the Grey Abbey Library. You had been minding your own business for the most part, taking a break from the hectic adventures of the city around you, and simply relaxing in your own body. Suddenly, however, this peace is disrupted when a loud crackling sound echoes from somewhere near the front entrance. Startled, you turn to face the entrance, your not-insignificant rear armament swinging wide enough to smack the side of a shelf and knock several items loose. You find more important things occupy your attention than cleaning up after your momentary distract, however, as you see the likely source of the unusual sound – the magic drake herself, at your own front door.";
 	say "     Seeing the one responsible for a specific part of your own transformation right here in the library, so far away from her usual haunts, is enough to make you speechless. Though you can't see it yourself, you suspect your own expression is similarly in a state of disbelief. The drake however is seemingly unbothered, or perhaps even somewhat pleased, by your reaction to her presence. Her relatively calm face shifts into a wide grin, rife with the smug aura you so associate with her, and she strides towards you. 'Oh, so this is where my familiar has been living, hmm? Not a bad little home, really, a fine place for my toy to stay when away from me.' Before you have time to truly process that, she reaches your position and throws a scaled arm around your shoulder, giving you a slight squeeze. 'Well, aren't you going to give me a tour?' Still slightly in a state of emotional disarray, and further distracted by the closeness of the overpowering figure, you nod dumbly, and start walking.";
 	WaitLineBreak;
@@ -1065,6 +1070,7 @@ instead of navigating Grey Abbey Library while (location of player is Red Light 
 	say "     'The next time you're ready to have a visit from your mistress, or even just wish to speak with me further, just use it.' She smirks at your still slightly bewildered expression. 'Something tells me you won't have any trouble understanding how it's used, isn't that right familiar?' With a loud chuckle, she steps away from you completely, and strolls purposefully back out of the library, leaving you still dazed and very aroused – something you're familiar with when it comes to the sorceress.";
 	CreatureSexAftermath "Player" receives "AssDildoFuck" from "Magic Drake";
 	ItemGain gilded staff by 1;
+	now Wallstuck is resolved;
 
 to say mdrakecontact:
 	if mdrakequest is 0: [first time scene]

--- a/Stripes/Candy Striper.i7x
+++ b/Stripes/Candy Striper.i7x
@@ -490,7 +490,7 @@ to say coondesc:
 [Update for WalkinEvents table]
 Table of NavInEvents (continued)
 Priority	Name	EventObject	EventConditions	EventRoom	LastEncounterTurn	CoolDownTurns	EncounterPercentage
-3	"LibraryCandyMeeting"	LibraryCandyMeeting	"[EventConditions_LibraryCandyMeeting]"	Grey Abbey Library	2500	2	100
+2	"LibraryCandyMeeting"	LibraryCandyMeeting	"[EventConditions_LibraryCandyMeeting]"	Grey Abbey Library	2500	2	100
 
 to say EventConditions_LibraryCandyMeeting:
 	if coonstatus is 1:

--- a/Taelyn/Anastasia Loyalty.i7x
+++ b/Taelyn/Anastasia Loyalty.i7x
@@ -109,9 +109,27 @@ after going to Half-Renovated Room while (Anastasia is in Half-Renovated Room an
 
 Section 3 - Anastasia Master/Slave Events
 
-after going to Grey Abbey Library while (Anastasia is booked and Loyalty of Anastasia is 10 and (the number of bunkered people + the number of booked people > 5) and "Unchained" is listed in Traits of Anastasia):
-	if debugactive is 1:
-		say "     DEBUG: Anastasia WALK-IN - HP of Anastasia: [HP of Anastasia], Loyalty of Anastasia: [Loyalty of Anastasia][line break]";
+Table of NavInEvents (continued)
+Priority	Name	EventObject	EventConditions	EventRoom	LastEncounterTurn	CoolDownTurns	EncounterPercentage
+1	"AnastasiaLibraryBrag"	AnastasiaLibraryBrag	"[EventConditions_AnastasiaLibraryBrag]"	Grey Abbey Library	2500	2	100
+
+Table of WalkInEvents (continued)
+Priority	Name	EventObject	EventConditions	EventRoom	LastEncounterTurn	CoolDownTurns	EncounterPercentage
+1	"AnastasiaLibraryBrag"	AnastasiaLibraryBrag	"[EventConditions_AnastasiaLibraryBrag]"	Grey Abbey Library	2500	2	100
+
+to say EventConditions_AnastasiaLibraryBrag:
+	if (Anastasia is booked and Loyalty of Anastasia is 10 and (the number of bunkered people + the number of booked people > 5) and "Unchained" is listed in Traits of Anastasia):
+		now CurrentWalkinEvent_ConditionsMet is true;
+
+Table of GameEventIDs (continued)
+Object	Name
+AnastasiaLibraryBrag	"AnastasiaLibraryBrag"
+
+AnastasiaLibraryBrag is a situation.
+ResolveFunction of AnastasiaLibraryBrag is "[ResolveEvent AnastasiaLibraryBrag]".
+Sarea of AnastasiaLibraryBrag is "Nowhere".
+
+to say ResolveEvent AnastasiaLibraryBrag:
 	say "     As you walk into the main lobby of the library, your attention is drawn to the huge demon prince sitting on one of the torn up comfy chairs, his boisterous laughter echoing throughout the building. 'Then there was this one time that my army attacked another hell realm. Of course we won, but the best part was when it came to the spoils! My imps brought in these two captives from the enemy, a guy and a girl who apparently were the prince and princess of their realm. Well, with one look, I knew exactly what needed to be done! So I grabbed the girl and pounded her pussy right there in front of her brother, and pretty soon, the screams turned into moaning, and I shot my load into the bitch haha! Being the nice ruler that I am though, I wasn't about to let her brother feel left out, so while she was passed out, I bent him over my throne. Damn, that slut was a squealer! By the end of the day, I had both of them worshiping my cock like they were born for it.'";
 	say "     Anastasia is apparently sharing his past conquests with your allies, some seem amused while others seem a bit disgusted. You are about to turn and leave when something else catches your ear. 'It's the same way with my new [italic type][master][roman type]. [SubjectProCap of Player] may act like [SubjectPro of Player] is in charge, but when we are alone, it's a completely different story. I mean, I can't keep the li'l subby slut off of my cock!' While Anastasia sharing his past with the others and attempting to open up about himself isn't necessarily a bad thing, talking about you and what happens between the two of you is a completely different matter.";
 	LineBreak;
@@ -173,6 +191,7 @@ after going to Grey Abbey Library while (Anastasia is booked and Loyalty of Anas
 		LineBreak;
 		say "     Rolling your eyes, you turn and start to walk away. After all, who cares what a demonic slave has to say? As you make your way out, you can still hear his laughter roaring throughout the library. While what he is doing may be slightly frustrating, you have better things to do than dealing with him and his frat boy mentality.";
 	increase Loyalty of Anastasia by 1;
+	now AnastasiaLibraryBrag is resolved;
 
 [after going to Half-Renovated Room while (HP of Anastasia > 1 and Loyalty of Anastasia is 10):
 	if debugactive is 1:


### PR DESCRIPTION
Update Anastasia Loyalty, Magic Drake to new walkin table.

Increased the priority of the LibraryCandyMeeting event to 2 at Wahn's recommendation, so that Candy doesn't take ages to arrive at the library.

These are the last files I'll be updating with the walkin table so I don't break anything or mess with active writer's files too much :)