### PR TITLE
Dragon Harem Fix

### DIFF
--- a/Voidsnaps/Alon.i7x
+++ b/Voidsnaps/Alon.i7x
@@ -24,7 +24,10 @@ to say Overflowing Grotto_Scent:
 	say "     Smelling like clean water and a hint of the ocean despite its freshwater nature, the Overflowing Grotto sparkles in the middle of the reservoir. There's a distinct hint of draconic musk that accompanies the moist scent, but it's not at all unpleasant.";
 
 instead of going east from The Edge Of The Swamp when "Hunting Alon" is not listed in Traits of Soot:
-	say "     A large form dives in and out of a pool in the distance. You get the feeling you shouldn't try to go over there, lest you offend it. After all, it looks big enough to eat you in a single gulp!";
+	if Alon is in Glittering Gate:
+		say "     The dragon's old rock pool sits empty now. The strange self-fueling fountain appears to have slowed down to a trickle, no longer at risk of destroying the already partially destroyed dam. There's no reason to revisit it!";
+	else:
+		say "     A large form dives in and out of a pool in the distance. You get the feeling you shouldn't try to go over there, lest you offend it. After all, it looks big enough to eat you in a single gulp!";
 
 Section 2 - Meeting Alon
 
@@ -161,6 +164,10 @@ instead of conversing Alon:
 			-- "Tell him what you're really planning.":
 				LineBreak;
 				say "      Taking a chance, you tell the dragon exactly what you want to do with him. Sexual conquest and all, you tell him in excruciating detail exactly what'll happen if he comes with you. You can almost hear crickets in the background as he tilts his head, and it comes as such a surprise when he bursts out laughing that you nearly jump out of your skin. 'What are we waiting for?! Usually the peasants scream and run when they see me watching them bathe, but all those dangly bits look fun to play with! Let's go, let's go!' Aggressively pressing his nose against your palm after heaving himself the rest of the way out of the pool, Alon shakes his head as the rune works its magic, with an expression like a person with a fly up their nose. When Soot appears, he looks at you with a surprised expression, stepping aside while Alon dives facefirst into the portal, happily splashing around in the pools nearby. You'll have to explain this to the mage later...";
+				move Alon to Glittering Gate;
+				TraitLoss "Hunting Alon" for Soot;
+				TraitGain "Captured Alon" for Soot;
+				TraitGain "MPreg" for Alon;
 			-- "Tell him you really have a better place for him to live.":
 				LineBreak;
 				say "     Deciding to play it safe, you tell the dragon that you want to move him somewhere he won't be destroying the environment. You happen to have somewhere that he can enjoy himself, as long as he doesn't mind a few... concessions. 'You're still lying, but I can smell why~!' With a grin, the dragon looks pointedly toward your crotch as though he can smell what you intend, nostrils flaring. 'Fuck it! I'm more than willing. Usually the peasants scream and run when they see me watching them bathe, but all those dangly bits look fun to play with! Let's go, let's go!' Aggressively pressing his nose against your palm after heaving himself the rest of the way out of the pool, Alon shakes his head as the rune works its magic, with an expression like a person with a fly up their nose. When Soot appears, he looks at you with a surprised expression, stepping aside while Alon dives facefirst into the portal, happily splashing around in the pools nearby. You'll have to explain this to the mage later...";
@@ -233,14 +240,13 @@ to say AlonFuckMenu:
 			WaitLineBreak;
 			say "     You're selfish with your orgasm, sitting down hard and rubbing your clit as you cream the dragon's shaft with squirt after squirt of femcum. His dick wriggles as you scoot back and forth, deprived of the friction it was enjoying, but that only works you to new heights, setting off a chain of miniature orgasms that slacken your jaw and mess the dragon's crotch further with your drooling fluids. You fall forward onto the dragon's stomach as the last orgasm quakes through your body, still impaled on a solid foot of hot dragon cock. Your legs turn into jelly when that shaft takes charge, slithering in and out of you with a rough rhythm that fills the sunny clearing with a sound reminiscent of stirring pasta. Too exhausted to take charge, you let it use your quivering quim, moaning aloud with every thrust and holding your bulging stomach with one hand as the dragon's hips thrust upward, slapping his balls on your ass cheeks on every downswing. His orgasm comes sooner than you'd hoped, but you only suffer a moment of disappointment before the fireworks begin inside you.";
 			say "      Like a sprinkler set on high, the dragon's dick swirls over your insides, hosing them with thick seed. With nowhere to go, it sprays out of your cunt at high pressure, basting your insides and coating your lower half with an increasingly thick layer of musky dragon. You're not sure how long Alon's cock power washes your insides, but it eventually slows to a trickle, falling out of you with a wet plop, and you catch your breath on his heaving belly, admiring the way the sun glints off of his scales. You barely notice when the eggs slip out of your loosened cunt, sending a shiver down your spine as they roll down between your legs and land in the puddle the two of you made. You're so wet that they slide right out, barely stretching you before they plop to the ground, and you zone out at the pleasant sensation, only coming to your senses once the dragon's snoring rumbles through his warm belly. Shaking your head at the dragon's typical response to an orgasm, you take the opportunity to gather your gear, cleaning yourself up as best you can and leaving him to nap in the sun. After all, you're sure you wore him out! Poor thing.";
-			AlonOffspringIncrease;
+			if OffSpringCount of Alon < 4:
+				increase OffSpringCount of Alon by 1;
 			NPCSexAftermath Player receives "AssFuck" from Alon;
 		-- "Nevermind.":
 			say "     Deciding against fucking the dragon for now, you tell Alon to wait until you're more in the mood, noting his slightly disappointed expression as he nods his head, still staring hungrily at your crotch and licking his lips. ";
 
-to AlonOffspringIncrease:
-	if OffSpringCount of Alon < 4:
-		increase OffSpringCount of Alon by 1;
+
 
 to say AlonFirstFuck:
 	let Alon_First_sex_Choices be a list of text;
@@ -271,6 +277,8 @@ to say AlonFirstFuck:
 			say "     Your stomach shifts just as the dragon's finished cleaning up most of his mess, and you groan aloud as you stretch from the inside, your pussy lips pushing apart. A rune-etched egg pulsating with light blue energy shoves the dragon's tongue aside and plops to the ground, soon followed by half a dozen others. You shiver with how good it feels, openly touching yourself despite the pair of draconic eyes fixed on you, and forget for a moment that you're not alone.";
 			say "     'That was... fast?' Alon tilts his head slightly, still licking a stray bit of cum from the corner of his mouth. He prods one of the eggs with a claw as you gather your wits, his expression one of amazement. 'If only my species were half as efficient!' Reequipping yourself on shaking legs as the dirty dragon rolls back into the water, you tell him it's nothing but Soot's magic at work. Pregnancy isn't nearly this quick under normal circumstances! Shaking your head at the weird ideas the mage's magic may have given the laid-back dragon, you prepare to leave.";
 			NPCSexAftermath Player receives "PussyFuck" from Alon;
+			if OffSpringCount of Alon < 4:
+				increase OffSpringCount of Alon by 1;
 
 
 
@@ -309,7 +317,8 @@ an everyturn rule:
 						LineBreak;
 						say "      Shaking your head, you clear the evil thought out, instead offering the exhausted dragon some comfort, patting his haunches and gently cleaning up the mess he made with a cloth from your bag. Of course, you still tease the poor thing, taking your time to wipe away his juices from his sensitive hole, and stroking his spent cock until it gives up its last pearly dribbles into your palm. You leave him to rest once you've had your fill of teasing, satisfied by the now-sleeping dragon's contentment.";
 					TraitLoss "Heavily Pregnant" for Alon;
-					AlonOffspringIncrease;
+					if OffSpringCount of Alon < 4:
+						increase OffSpringCount of Alon by 1;
 					now ImpregTimer of Alon is 0; [pregnancy reset]
 
 to say AlonBirthSex:
@@ -317,5 +326,7 @@ to say AlonBirthSex:
 	say "     Taking the dragon's soft muzzle as an invitation, you hump away with wild abandon, gripping his cheeks as you feed him a steadily growing trickle of arousal. It's not quite the same as his ass, but the soft tongue wringing your dick with expert pressure sure gives it a run for its money, and you feel as though that suction will draw your balls up through your cock if you're not careful. You see no point in holding back, so you let the growing sensation in your lower stomach reach its crescendo, washing over you as you fill his mouth with rope after rope of cum. That tongue milks you for everything you can give, and the dragon suckles as you bury yourself to the root, swallowing the evidence of your orgasm without complaint and begging for more.";
 	WaitLineBreak;
 	say "     Softened and running dry, you tug yourself free with a wet plop, patting the dozing dragon's muzzle as he settles in for a well-deserved nap. He looks so peaceful with a bit of your cum on his lower lip and his stretched ass on display that you can't help but wonder if he's taking advantage of this situation even more than you are. Perhaps this is what he wanted all along, just sucking cock, laying eggs, and lazing about in the water!";
+	if a random chance of 1 in 2 succeeds:
+		now ImpregTimer of Alon is 1;
 
 Alon ends here.

--- a/Voidsnaps/Helios.i7x
+++ b/Voidsnaps/Helios.i7x
@@ -92,6 +92,8 @@ to say ImpregHelios:
 			say "     DEBUG: Can't impregnate Helios, already pregnant!";
 
 to say HeliosDesc:
+	if debugactive is 1:
+		say "     <Helios has laid [OffspringCount of Helios] clutches.>";
 	say "     Standing at an impressive 8 feet at the shoulder, Helios stares down at you with curious amber eyes, his tail swaying behind him. A mix of red, brown, and orange scales adorn his bulky body, giving the appearance of magma, and two curling horns accent his masculine feral face. When he shifts in place, you catch a glimpse of two swinging, leathery dark red balls between his legs, beneath a fat sheath of the same color. A private peek would show a draconic cock tucked away inside, covered with ridges. Helios appears uncomfortable when you look closer at him, and he unconsciously leans away from you, though you can tell by the peeking tip of his manhood that it's all an act.";
 	if "Slightly Pregnant" is listed in Traits of Helios:
 		say "     His stomach shows the slightest bulge, as though he's had a big breakfast, but you know what that paunch hides. It seems he knows it too, and when he notices you staring, he pointedly looks away, sucking in his gut as if denying the fact that you've knocked him up. He fails after a moment of holding his breath, and settles for tucking his tail around himself, though it does little to hide his eggnancy.";
@@ -384,6 +386,7 @@ to say HeliosFuckMenu:
 			say "     A conveniently placed rock saves the dragon's balls from your weight, raising you to just the right height to nuzzle your dick against that heated silk. To your surprise, he's already slightly warmed up, and a bit of slickness greets your cockhead, letting you slip right in. You taunt him with this knowledge as you hilt, asking him whether he's been playing with himself while he waits for you. 'I have to keep myself clean. I certainly wasn't using my tongue for your benefit.' The dragon's ashamed whisper floats over his shoulder, accompanied by a whorish moan. 'It's none of your business.' A hint of arrogance slips into his voice, alongside the dripping desire you're milking from him as you introduce him to the novel sensation of a deep fuck.";
 			WaitLineBreak;
 			say "     Slapping the dragon's rump and punishing him for his insolence with a heavy rhythm that slaps your hips against his heated rear, you chastise him for refusing to admit the truth. It's easy to see that he rimmed himself because he missed your cock. He wouldn't be this loose if he hadn't spent a long time fucking his ass with his tongue! Overwhelmed by the repeated assault on his sensitive prostate, the dragon can barely form a coherent sentence, his words coming in a discombobulated huff. Straining your neck, you watch as he lolls his tongue, a pleasured expression on his face that hastily changes to a forced wince as he notices your gaze. 'This is nothing but a punishment. A duty I must fulfill for some imagined slight. I wouldn't enjoy such filthy things.'";
+			WaitLineBreak;
 			say "     Withdrawing, you tease the dragon, telling him that if he doesn't enjoy your efforts, you can ask Soot for magical aid. Surely there's some way to prevent him from feeling something so 'vile.' Maybe you should stop here and ask. Of course, that'll mean you'll have to leave him there, with his ass in the air and an untouched dick. ";
 			if OffspringCount of Helios > 3:
 				LineBreak;
@@ -410,7 +413,8 @@ to say HeliosFuckMenu:
 			WaitLineBreak;
 			say "     It doesn't take long for that churning sensation to reappear, coaxing you to open your legs and spread your cheeks. Stimulating ridges work their way down your passage. You throw back your head, moaning as the first one pops free with little effort, spreading your hole wide and bringing with it a thick coating of dragon cum. The next comes with ease, and by the time the last one pops free, you're openly fingering your hole in hopes of another. Sadly, you've finished laying, standing on shaky legs, re-equipping yourself, and leaving the pile of eggs for Soot to collect.";
 			NPCSexAftermath Player receives "AssFuck" from Helios;
-			HeliosOffspringIncrease;
+			if OffspringCount of Helios < 4:
+				increase OffSpringCount of Helios by 1;
 		-- "Milk his cock with your pussy.":
 			LineBreak;
 			say "     You feel like giving Helios's cock a workout this time. Telling him so, you strip off your gear and toss it in a haphazard pile nearby. Making it clear what you want, you find a semi-comfortable rock to lean back on and spread your legs, giving the dragon a view of your spread ass cheeks and dripping cunt. Telling him to get to work on pleasing you, you crook your finger toward him. Swallowing audibly, the dragon looks from your presented pussy to the door, then back as though weighing his options and contemplating resistance. With a sigh, he seems to decide not to protest, slotting his nose between your legs. Grumbling, he lolls his tongue out, letting it whisk over your pussy lips for a moment before he grimaces and pulls back. 'Is there no other way?'";
@@ -421,16 +425,15 @@ to say HeliosFuckMenu:
 			WaitLineBreak;
 			say "     It doesn't take long for that churning sensation to reappear, coaxing you to open your legs and spread pussy with excited fingers. Stimulating ridges work their way down your passage. You throw back your head, moaning as the first one pops free with little effort, spreading you wide and bringing with it a thick coating of dragon cum. The next comes with ease, and by the time the last one pops free, you're openly fingering your sloppy pussy in hopes of another. Sadly, you've finished laying, standing on shaky legs, re-equipping yourself, and leaving the pile of eggs for Soot to collect.";
 			NPCSexAftermath Player receives "PussyFuck" from Helios;
-			HeliosOffspringIncrease;
+			if OffspringCount of Helios < 4:
+				increase OffSpringCount of Helios by 1;
 		-- "Nevermind.":
 			LineBreak;
 			say "     Deciding against fucking the dragon for now, you tell him to wait until you're more in the mood, noting his slightly disappointed expression as he nods his head, still staring hungrily at your crotch. ";
 			if OffspringCount of Helios > 2:
 				say "You hear him mumble something under his breath about being unable to wait, but he behaves, reclining and letting his cock soften with a hopeful expression, as though you'll take pity on him. You should probably try for another clutch soon, before the poor thing goes TOO stir-crazy.";
 	
-To HeliosOffspringIncrease:
-	if OffspringCount of Helios < 4:
-		increase OffSpringCount of Helios by 1;
+
 
 Section 5 - Helios Pregnancy
 
@@ -453,10 +456,11 @@ an everyturn rule:
 				say "     [bold type]Your thoughts wander back to Helios, and you feel a need to go check in on him. You may have missed his egg-laying![roman type][line break]";
 				add "Absent_Birth" to Traits of Helios; [memory of the birth of human dog offspring without the player present. trait just there for completeness, does nothing.]
 				TraitLoss "Heavily Pregnant" for Helios;
-				HeliosOffspringIncrease;
-				now ImpregTimer of Helios is 0; [pregnancy reset]
+				now ImpregTimer of Helios is 0; [Pregnancy Reset]
+				if OffspringCount of Helios < 4:
+					increase OffSpringCount of Helios by 1;
 			else: [player is next to Helios] [TODO: Add mentions of other offspring]
-				say "      Helios groans and lies on his side, his legs forced apart by his massvely swollen stomach. His tongue hangs out of his mouth, and you can see his obsidian pucker flex with effort as a soft glow illuminates it. Pulsing with an unmistakably fiery aura, his first egg tests the limits of his hole, accompanied by a slow trickle of lubricant, then slides out, leaving his ass gaping and his  cock throbbing. Cursing your name under his breath, he bears down, readying the next. ";
+				say "      Helios groans and lies on his side, his legs forced apart by his massvely swollen stomach. His tongue hangs out of his mouth, and you can see his obsidian pucker flex with effort as a soft glow illuminates it. Pulsing with an unmistakably fiery aura, his first egg tests the limits of his hole, accompanied by a slow trickle of lubricant, then slides out, leaving his ass gaping and his cock throbbing. Cursing your name under his breath, he bears down, readying the next. ";
 				if OffspringCount of Helios is 0: [first time]
 					say "Helios grimaces as  each egg reaches its apex, stretching his hole to its fullest, and then slides out of him. He sighs with relief, only to clench his teeth again as the next jostles for position. At least half a dozen eggs come in quick succession, pooling by his haunches, and by the time he finishes, his thick hauches shine with messy lubricant, his hole loosened enough that you can see his soft pink inner walls, still spasming despite the birth's near finish. When the last egg left queues up, he lets out a high pitched whine, and his cock heaves, dousing the ground below in a thick layer of cum.";
 					if Player is male:
@@ -469,9 +473,10 @@ an everyturn rule:
 						else:
 							say "      Shaking your head, you clear the evil thought out, instead offering the exhausted dragon some comfort, patting his haunches and gently cleaning up the mess he made with a cloth from your bag. Of course, you still tease the poor thing, taking your time to wipe away his juices from his sensitive hole, and stroking his spent cock until it gives up its last pearly dribbles into your palm. You leave him to rest once you've had your fill of teasing, satisfied by the now-sleeping dragon's contentment.";
 						TraitLoss "Heavily Pregnant" for Helios;
-						HeliosOffspringIncrease;
-						now ImpregTimer of Helios is 0; [pregnancy reset]
-				else if OffspringCount of Helios > 2:
+						now ImpregTimer of Helios is 0; [Pregnancy Reset]
+						if OffspringCount of Helios < 4:
+							increase OffSpringCount of Helios by 1;
+				else if OffspringCount of Helios > 0 and OffspringCount of Helios < 4:
 					say "A moan slips out of the gravid dragon's mouth as he passes the first egg, accompanied by his cock flexing and firing off a juicy string of pre across his roiling stomach. His eyes shoot open as he realizes you're there, and he bites his lower lip as the next crests its apex, trying his best to hold back another. If you didn't know better, you'd think he's enjoying being forced to give birth to your eggs! With each egg that stretches his poor hole, he loses a little more control, until he rolls over onto his back, front paws clutching his heaving stomach and churning balls on display. The final egg is slightly larger than the rest, and it seems he's unable to hold back just how good it feels, breaking his muffled silence to scream his pleasure. With that cry reverberating, the egg slips free of his ruined hole, triggering what appears to be quite an intense orgasm. By the time he finishes spasming, claws digging into the dirt below, he's covered chin to cock in his own seed, staring off into space with a glazed look.";
 					if Player is male:
 						LineBreak;
@@ -483,9 +488,10 @@ an everyturn rule:
 						else:
 							say "      Shaking your head, you clear the evil thought out, instead offering the exhausted dragon some comfort, patting his haunches and gently cleaning up the mess he made with a cloth from your bag. Of course, you still tease the poor thing, taking your time to wipe away his juices from his sensitive hole, and stroking his spent cock until it gives up its last pearly dribbles into your palm. You leave him to rest once you've had your fill of teasing, satisfied by the now-sleeping dragon's contentment.";
 						TraitLoss "Heavily Pregnant" for Helios;
-						HeliosOffspringIncrease;
-						now ImpregTimer of Helios is 0; [pregnancy reset]
-				else if OffspringCount of Helios > 4:
+						now ImpregTimer of Helios is 0; [Pregnancy Reset]
+						if OffspringCount of Helios < 4:
+							increase OffSpringCount of Helios by 1;
+				else if OffspringCount of Helios > 3: [Future-proofed for 4+]
 					say "Helios can't hold onto his cursing, pained expression for long, and as you watch, a slutty expression comes over his face. Rather than seeming ashamed, he's embraced his role as a broodmother, and even seems to be showing off for you. He rolls over onto his stomach with some effort, tail lifted high and cock on display as the first runed egg pushes free, plopping onto the ground below with a soft thud. Moaning like a wanton whore, he shakes his ass as the next makes its way down his egg chute, his hole bulging outward and lubricant dribbling down over his cock, mixing with the free flowing pre that messes the ground below. The next few eggs pass with little resistance, giving you a view of the dragon's loosened hole, until the final, largest one stretches him out. Helios's body tenses as it stretches him out, and he cums himself silly as it reaches its apex, falling to the floor in a puddle of cum. Exhausted, he collapses forward into his own mess, tail still lazily lifted over his back and ruined hole on display.";
 					if Player is male:
 						LineBreak;
@@ -496,14 +502,17 @@ an everyturn rule:
 							say "[HeliosBirthSex]";
 						else:
 							say "      Shaking your head, you clear the evil thought out, instead offering the exhausted dragon some comfort, patting his haunches and gently cleaning up the mess he made with a cloth from your bag. Of course, you still tease the poor thing, taking your time to wipe away his juices from his sensitive hole, and stroking his spent cock until it gives up its last pearly dribbles into your palm. You leave him to rest once you've had your fill of teasing, satisfied by the now-sleeping dragon's contentment.";
-			TraitLoss "Heavily Pregnant" for Helios;
-			HeliosOffspringIncrease;
-			now ImpregTimer of Helios is 0; [pregnancy reset]
+							TraitLoss "Heavily Pregnant" for Helios;
+							now ImpregTimer of Helios is 0; [Pregnancy Reset]
+						if OffspringCount of Helios < 4:
+								increase OffSpringCount of Helios by 1;
 
 to say HeliosBirthSex: [Fuck his stretched ass!]
+	TraitLoss "Heavily Pregnant" for Helios;
+	now ImpregTimer of Helios is 0; [Pregnancy Reset. He just gave birth!]
 	LineBreak;
 	say "     Deciding to take advantage of Helios, you step up to his ruined ass and pat his haunches, quickly discarding your things and bringing your cock to bear. The steaming heat rolling off that well-lubricated and stretched hole teases your cock tip, and you can't resist its siren's call, shoving in and using Helios's tail as an anchor to get better leverage. It's surprisingly tight despite its well-used appearance, suckling at your cock and welcoming you in deeper with rolling muscles. ";
-	if OffspringCount of Helios <= 1:
+	if OffspringCount of Helios < 2:
 		say "Helios's eyes widen as you stuff yourself inside him, and he attempts to crawl away, but his efforts only drag his clamping hole along your cock, encouraging you to close the distance before he can slip off of you. He groans his displeasure, but you can feel him subtly press back against your dick with each thrust, and by the time you set up a heavy thrust, slapping your hips into his thick haunches, his protests have melted into soft huffing murmurs.";
 		say "     You pat the still-resistant dragon's ass with your free hand, rewarding his acquiescence with a long pause as your dick hilts inside him, letting him feel just how excited he's gotten you. You tell him he's such a good egg layer that you couldn't resist pumping a new clutch into him, and he should feel proud that he's still so sexy even after such intense labor. It's subtle, but you can feel his inner walls clutch at your cock more insistently the more you describe his subservience, and when you follow it up by telling him what a sexy whore he is, a muffled moan leaves the dragon's mouth, as though he does not deny it. The longer you fuck the dragon, the more he relaxes into your rhythm, pushing back into every thrust and letting his tongue loll out of the side of his scaly mouth. He can try to deny it all he wants, but that dragon ass exists for taking dick! Even his cock seems to agree, pulsing back to life and creaming the ground below in anticipation of another load in his juicy hole.";
 		WaitLineBreak;
@@ -512,7 +521,7 @@ to say HeliosBirthSex: [Fuck his stretched ass!]
 		say "Helios groans with pleasure as you stuff yourself past his loosened rim, weakly protesting but shoving backward to take you to the hilt. Even though his mouth says one thing, his body seems more than willing to take its next clutch, and his silky, stretched hole milks your dick for all its worth. Without even an attempt to escape, you're clear to fuck him as you like, and he even peers backward as though he wants to encourage you but thinks better of it. Taking advantage of the wyrm's partial acceptance, you hold onto his tail for dear life, thrusting with all of your strength and reveling the sloppy, wet heat that suckles at your cock. You're not going to last long in the dragon's sauna of an ass, but you attempt to hold out as long as you can, gritting your teeth in an attempt to hold yourself back. Spurred on by that greedy hole, you tell him what an obedient whore he is, praising him for lifting his tail for you and begging for another clutch.";
 		WaitLineBreak;
 		say "     Tightening at your words despite a brief protest, the dragon appears to get off on your sentiment, dragging his hips to and fro to grind his dick on the cum-soaked dirt below. Quaking balls draw up until they provide a convenient seat to wrap your thighs around, and he cums long before you do, letting loose twin puffs of steam from his nostrils. Spurred on by the slutty dragon's orgasm, you pump yourself deep into his guts, hilting yourself and thrusting wildly through your orgasm. Rope after rope christens his greedy inner walls, and he clamps down so hard that you doubt you could pull out if you wanted to, as though his body begs you for another clutch. Of course, you're more than willing to oblige, staying buried within those greedy walls until the last pitiful dribble of cum drains from your softened cock.";
-	else if OffspringCount of Helios >= 3:
+	else if OffspringCount of Helios > 2:
 		say "'Give me more!' Helios groans as you stuff yourself into his backdoor. His hips quake with unrestrained pleasure when he feels you slide to the hilt, and more unfiltered sluttiness pours forth from his lips. 'Breed me. Please. I need more eggs. Don't ever stop fucking me.' All the while, the dragon backs up, trying to cram more of your dick than is humanly possible past his hole until his weakened body has you pinned against a nearby wall. Still strong enough to get his way and worked up enough that he doesn't care how it looks, he shoves backward in a wanton rhythm, fucking his loosened slutty hole on your cock as though you were nothing but a living dildo.";
 		say "     You could struggle free if you wanted to, but confronted with the warm embrace of thick dragon haunches and milked by the heavy backward thrust of those insistent hips, you can only thrust in time, giving Helios what he wants. His tail base provides a convenient handhold to stop you from falling, and the heavy balls that draw up between your legs with the fevered coupling, proof that he's close to his finish, are a convenient seat. You praise Helios for giving into what he wants, grunting with every heavy slam of dragon ass that threatens to knock you through the wall. At this point, it's more like he's fucking you than the other way around, but the drooling dragon tongue and vacant stare leveled at you over the dragon's shoulder makes it clear that it's you who's in charge.";
 		WaitLineBreak;

--- a/Voidsnaps/Soot.i7x
+++ b/Voidsnaps/Soot.i7x
@@ -82,18 +82,20 @@ to say SootConversationMenu:
 		now sortorder entry is 2;
 		now description entry is "Ask Soot what this place is and why he brought you here.";
 	[]
-	if "Helios Captured" is listed in Traits of Soot and resolution of Hard Bargain is 1:
+	if "Helios Captured" is listed in Traits of Soot and resolution of Hard Bargain is 1 and "Hunting Alon" is not listed in Traits of Soot and Alon is not in Glittering Gate:
 		choose a blank row in table of fucking options;
 		now title entry is "Ask Soot what your next target is after Helios";
 		now sortorder entry is 3;
 		now description entry is "Ask Soot where your next dragon quarry is.";
 		sort the table of fucking options in sortorder order;
+	[]
 	if OffSpringCount of Helios is 4 and OffSpringCount of Alon is 4:
 		choose a blank row in table of fucking options;
 		now title entry is "Tell Soot you've been upholding your end of the bargain";
 		now sortorder entry is 4;
 		now description entry is "Tell Soot that it seems like you've birthed quite a few eggs for him.";
 		sort the table of fucking options in sortorder order;
+	[]
 	repeat with y running from 1 to number of filled rows in table of fucking options:
 		choose row y from the table of fucking options;
 		say "[link][y] - [title entry][as][y][end link][line break]";
@@ -225,6 +227,7 @@ to say SootIntroduction:
 
 to say AlonHuntStart:
 	say "     Asking Soot whether he has another target for you to hunt, you eagerly lean over the desk, wondering aloud if they'll be as hard to fight as Helios was. Soot sips at a cup of tea, waving his hand to stop your questions and pulling your palm over to inspect the spot where the rune was before you used it on Helios. Drawing another, more intricate series of symbols, he releases it and waves you toward the exit. 'You know what to do! Find him, touch him, and I'll bring him here once you defeat him!' Despite his dismissive and jovial attitude, you can see the cup shake in his hands. Is he excited about getting to leave this place?";
+	TraitGain "Hunting Alon" for Soot;
 
 Section 2 - After Defeating Helios
 
@@ -233,7 +236,7 @@ Priority	Name	EventObject	EventConditions	EventRoom	LastEncounterTurn	CoolDownTu
 1	"Hard Bargain"	Hard Bargain	"[EventConditions_Hard Bargain]"	Pocket Universe	2500	2	100
 
 to say EventConditions_Hard Bargain:
-	if "Helios Captured" is listed in Traits of Soot: [list of conditions here]
+	if "Helios Captured" is listed in Traits of Soot and "Hard Bargain" is not listed in Traits of Helios: [list of conditions here]
 		now CurrentWalkinEvent_ConditionsMet is true;
 
 Table of GameEventIDs (continued)
@@ -279,19 +282,20 @@ to say ResolveEvent Hard Bargain:
 			LineBreak;
 			say "     Rubbing one hand on the back of your head, you weigh the situation. You're not certain whether you want to go through with things, but you don't want to be rude. After all, you've come this far. Can you come back later and give Soot and answer? 'Certainly. Let me know if you've come to a decision. In the meantime, I'll allow you to... inspect your prize.' Winking, Soot produces a book from below the desk and shoos you off toward the door. It seems he wants you to see the creature you captured before you make your decision!";
 			now Resolution of Hard Bargain is 2; [Not sure yet.]
-		now Hard Bargain is resolved;
+	now Hard Bargain is Resolved;
+	TraitGain "Hard Bargain" for Helios;
 
 instead of navigating Pocket Universe while (Resolution of Hard Bargain is 100):
 	say "     You attempt to search for the usual door to Soot's pocket Universe, but give up after a while. It's nowhere to be found, and you doubt you will ever be allowed in again. Maybe [bold type]you should have just gone along with his plan if you wanted to continue interacting with him.[roman type][line break]";
 
-Section 3 - After Defeating Alon
+Section 3 - After Winning Over Alon
 
 Table of NavInEvents (continued)
 Priority	Name	EventObject	EventConditions	EventRoom	LastEncounterTurn	CoolDownTurns	EncounterPercentage
 1	"Whatever Works"	Whatever Works	"[EventConditions_WhateverWorks]"	Pocket Universe	2500	2	100
 
 to say EventConditions_WhateverWorks:
-	if "Alon Captured" is listed in traits of Soot: [list of conditions here]
+	if "Alon Captured" is listed in traits of Soot and "Whatever Works" is not listed in traits of Alon: [list of conditions here]
 		now CurrentWalkinEvent_ConditionsMet is true;
 
 Table of GameEventIDs (continued)
@@ -305,7 +309,8 @@ Level of Whatever Works is 0. [minimum level to encounter randomly]
 
 to say ResolveEvent Whatever Works:
 	say "     As soon as you return to the pocket Universe, Soot meets you at the door, an eyebrow raised. 'Your... friend... has been asking after you. He seems rather excited to be here. I've never seen a dragon quite this eager for captivity.' Soot waves his hand at your explanation with a knowing grin and shakes his head. 'No, no. I don't need details. It truly doesn't matter HOW you fulfill our bargain. Just let me know if you need any restrictions placed. I'll leave you to it!' Thanking the dragomancer for his discretion, you reiterate that you plan to pump out more eggs for him to use as he sees fit.";
-	now Whatever Works is resolved;
+	now Whatever Works is Resolved;
+	TraitGain "Whatever Works" for Alon;
 
 Section 4 - Interactions After Enough Egg Births
 


### PR DESCRIPTION
Fixed Alon being unavailable. Fixed Helios pregnancy progression. Fixed Quest. Fixed Alon's location having improper description after he leaves for the pocket dimension. Fixed Soot's dialogues. Fixed fixing a fix's fixfix.