### PR TITLE
Enable room scents

### DIFF
--- a/Core Mechanics/Smell.i7x
+++ b/Core Mechanics/Smell.i7x
@@ -65,6 +65,14 @@ carry out heresniffing:
 [	repeat with X running through all the visible things in the Location of Player:
 		try sniffing X; ]
 
+instead of sniffing a room (called x):
+	if location of Player is not x:
+		say "You can't smell that place from here.";
+	else if scent of x is empty:
+		say "This place smells as you'd expect.";
+	else:
+		say "[scent of x][line break]";
+
 
 Section 2 - The player
 


### PR DESCRIPTION
Allows the scent property for rooms to be displayed when heresniffing. After the commit, "smell here" shows either the custom override (if defined elsewhere), the room scent, or the default string. Has no effect beyond heresniffing (as a room name still won't resolve to a valid thing).