### PR TITLE
Restore ewe descriptive

### DIFF
--- a/Luneth/Ewe.i7x
+++ b/Luneth/Ewe.i7x
@@ -70,7 +70,7 @@ When Play begins:
 	now attack entry is "[one of]She moves forward and rubs her soft wool over your body.[or]She lowers her head down and charges, knocking you back.[or]The ewe eyes you carefully before striking at your weak spots![or]The naked ewe pauses and strokes her soft wool teasingly, distracting you from the fight![or]The ewe windmills her arms as she charges forward, somehow managing to land a lucky blow.[at random]";
 	now defeated entry is "[ewe loss]";
 	now victory entry is "[ewe attack]";
-	now desc entry is "";
+	now desc entry is "[Ewe_desc]";
 	now face entry is "short black muzzle"; [ Face description, format as "Your face is [Face of Player]." ]
 	now body entry is "stocky, but feminine, with lovely curves to your body. Your arms are thinner, ending in dainty, hoof-like hands which struggle to handle items at times. Your legs have strong thighs for leaping and crossing rough terrain and slender calves ending in dark hooves";
 	now skin entry is "[one of]woolly[or]soft wool[or]white fleeced[at random]";


### PR DESCRIPTION
The ewe critter had its descriptive string updated years ago, but the new code was never hooked up after being moved. This restores the description so the appropriate string runs when a random encounter fires.