### PR TITLE
Correct invalid loot entry

### DIFF
--- a/Sundered Dragon/Dragon Breeder.i7x
+++ b/Sundered Dragon/Dragon Breeder.i7x
@@ -80,7 +80,7 @@ When Play begins:
 	now Cunt Tightness entry is 20;
 	now SeductionImmune entry is true;
 	now libido entry is 60; [ As part of infection, the Player will be gradually moved towards this value; also used for the creature's seduce defense as a penalty ]
-	now loot entry is "-";
+	now loot entry is "";
 	now lootchance entry is 0; [ Chance of loot dropping 0-100 ]
 	now MilkItem entry is "Dragon Breeder milk";
 	now CumItem entry is "Dragon Breeder cum"; [ Item to be given to the player if they have this infection and jerk off. ]

--- a/Sundered Dragon/Hermacore.i7x
+++ b/Sundered Dragon/Hermacore.i7x
@@ -83,7 +83,7 @@ When Play begins:
 	now Cunt Tightness entry is 20;
 	now SeductionImmune entry is false;
 	now libido entry is 60; [ As part of infection, the Player will be gradually moved towards this value; also used for the creature's seduce defense as a penalty ]
-	now loot entry is "-";
+	now loot entry is "";
 	now lootchance entry is 0; [ Chance of loot dropping 0-100 ]
 	now MilkItem entry is "Hermacore Cream";
 	now CumItem entry is "Hermacore Cum"; [ Item to be given to the player if they have this infection and jerk off. ]

--- a/Sundered Dragon/Margay Taur.i7x
+++ b/Sundered Dragon/Margay Taur.i7x
@@ -72,10 +72,10 @@ When Play begins:
 	now Cunt Tightness entry is 20;
 	now SeductionImmune entry is false;
 	now libido entry is 60; [ As part of infection, the Player will be gradually moved towards this value; also used for the creature's seduce defense as a penalty ]
-	now loot entry is "-";
+	now loot entry is "";
 	now lootchance entry is 0; [ Chance of loot dropping 0-100 ]
 	now MilkItem entry is "margay taur milk";
-	now CumItem entry is "-"; [ Item to be given to the player if they have this infection and jerk off. ]
+	now CumItem entry is ""; [ Item to be given to the player if they have this infection and jerk off. ]
 	now TrophyFunction entry is "-"; [ Function to generate a list of optional loot items, of which the player can choose one after victory. ]
 	now scale entry is 5; [ Number 1-5, approx size/height of infected PC body: 1=tiny, 3=avg, 5=huge ]
 	now body descriptor entry is "[one of]plump[or]tubby[or]fat[or]voluptuous[or]chubby[or]cuddly[or]huggable[at random]";


### PR DESCRIPTION
A few recent stub infections introduced some bad loot entries into the critters table, causing occasional errors when the standard random reward code (that picks a random critter and tries to use its loot entry if not "" or " ") was run. This commit just removes the bad entries (in lieu of any more robust guards to ItemGain or the reward code).