### PR TITLE
Switch to adjectives for combat setup

### DIFF
--- a/AGentlemanCalledB/Fire Sprite.i7x
+++ b/AGentlemanCalledB/Fire Sprite.i7x
@@ -297,7 +297,7 @@ to say PrepCombat_Fire Sprite:
 		setmongender 3; [creature is male]
 		project the figure of FireSpriteMale_icon;
 	now sex entry is "Female";
-	if "Male Preferred" is listed in the feats of Player, now sex entry is "Male";
+	if Player is MalePreferred, now sex entry is "Male";
 	if "Herm Preferred" is listed in the feats of Player, now sex entry is "Both";
 
 Section 2 - Creature Insertion

--- a/AGentlemanCalledB/Jaguar Warrior.i7x
+++ b/AGentlemanCalledB/Jaguar Warrior.i7x
@@ -477,7 +477,7 @@ An everyturn rule:
 				say "     You drop to a knee as you feel a surge of heat roll through you, your feline physique shifting as the power of the jaguar headdress you're wearing ripples through your feline body, remaking you into a powerful jungle predator.";
 			setmonster "Jaguar Warrior";
 			choose row MonsterID from the Table of Random Critters;
-			if "Female Preferred" is not listed in feats of Player:
+			if Player is not FemalePreferred:
 				now sex entry is "Both";
 			now hoodequipped is 1;
 		infect "Jaguar Warrior";
@@ -487,7 +487,7 @@ An everyturn rule:
 		now hoodequipped is 0;
 		setmonster "Jaguar Warrior";
 		choose row MonsterID from the Table of Random Critters;
-		if "Male Preferred" is not listed in feats of Player:
+		if Player is not MalePreferred:
 			now sex entry is "Female";
 
 Table of Game Objects (continued)

--- a/AGentlemanCalledB/Pink Poodle.i7x
+++ b/AGentlemanCalledB/Pink Poodle.i7x
@@ -139,7 +139,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Pink Poodle:
 	setmongender 4; [creature is female]
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/AGentlemanCalledB/Sugar Glider.i7x
+++ b/AGentlemanCalledB/Sugar Glider.i7x
@@ -121,7 +121,7 @@ to say PrepCombat_Sugar Glider:
 	project the Figure of SugarGlider_icon;
 	setmongender 4; [creature is female]
 	choose row MonsterID from Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Blue Bishop/Feral Sea Dragon.i7x
+++ b/Blue Bishop/Feral Sea Dragon.i7x
@@ -18,10 +18,8 @@ to say fsdm attack:
 			if Name entry is "Feral Sea Dragoness":
 				now MonsterID is y;
 				break;
-		if "Male Preferred" is listed in feats of Player:
+		if Player is MalePreferred:
 			now sex entry is "Male";
-		else if "Female Preferred" is listed in feats of Player:
-			now sex entry is "Female";
 		else if "Herm Preferred" is listed in feats of Player:
 			now sex entry is "Both";
 		else:
@@ -713,10 +711,8 @@ to say PrepCombat_Feral Sea Dragon:
 	now firebreathready is false;
 	now tempnum2 is 0;
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
-	else if "Female Preferred" is listed in feats of Player:
-		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";
 	else:

--- a/Blue Bishop/Feral Sea Dragoness.i7x
+++ b/Blue Bishop/Feral Sea Dragoness.i7x
@@ -21,9 +21,7 @@ to say fsdf attack:
 			if Name entry is "Feral Sea Dragon":
 				now MonsterID is y;
 				break;
-		if "Male Preferred" is listed in feats of Player:
-			now sex entry is "Male";
-		else if "Female Preferred" is listed in feats of Player:
+		if Player is FemalePreferred:
 			now sex entry is "Female";
 		else if "Herm Preferred" is listed in feats of Player:
 			now sex entry is "Both";
@@ -528,9 +526,7 @@ to say PrepCombat_Feral Sea Dragoness:
 	now firebreathcount is 0;
 	now firebreathready is false;
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
-		now sex entry is "Male";
-	else if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Blue Bishop/Goblin.i7x
+++ b/Blue Bishop/Goblin.i7x
@@ -541,7 +541,7 @@ name(text)	PrepFunction(text)
 
 to say PrepCombat_Goblin:
 	choose row with name of "Goblin" from the Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Blue Bishop/Pewter Consort.i7x
+++ b/Blue Bishop/Pewter Consort.i7x
@@ -661,9 +661,7 @@ name(text)	PrepFunction(text)
 
 to say PrepCombat_Pewter Consort:
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
-		now sex entry is "Male";
-	else if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Blue Bishop/Sierrasaur.i7x
+++ b/Blue Bishop/Sierrasaur.i7x
@@ -353,9 +353,9 @@ name(text)	PrepFunction(text)
 
 to say PrepCombat_Sierrasaur:
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
-	else if "Female Preferred" is listed in feats of Player:
+	else if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";
@@ -579,9 +579,9 @@ Usedesc of earthen seed is "[usesierraseed]";
 to say usesierraseed:		[only alters sizes, not gender]
 	choose row MonsterID from Table of Random Critters;
 	setmonster "Sierrasaur";
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
-	else if "Female Preferred" is listed in feats of Player:
+	else if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Damaged/Wyvern.i7x
+++ b/Damaged/Wyvern.i7x
@@ -683,11 +683,11 @@ to say PrepCombat_Wyvern:
 				malepronouns;
 		psycheeval;
 		libidoeval;
-		if "Female Preferred" is listed in feats of Player:
+		if Player is FemalePreferred:
 			now sex entry is "Female";
 		else if "Herm Preferred" is listed in feats of Player:
 			now sex entry is "Both";
-		else if "Male Preferred" is listed in feats of Player:
+		else if Player is MalePreferred:
 			now sex entry is "Male";
 		else if WYVGEN is 1:
 			now sex entry is "Male";

--- a/Gherod/Giant.i7x
+++ b/Gherod/Giant.i7x
@@ -498,7 +498,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Human Giant:
 	setmongender 3; [creature is male]
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Guest Writers/Cute Chinchilla Girl.i7x
+++ b/Guest Writers/Cute Chinchilla Girl.i7x
@@ -84,10 +84,8 @@ to say PrepCombat_Chinchilla:
 		now chindem is true;
 	else:
 		now chindem is false;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
-	else if "Female Preferred" is listed in feats of Player:
-		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";
 	else:
@@ -294,10 +292,8 @@ Usedesc of tuft of chin fur is "[tuft of chin fur use]";
 to say tuft of chin fur use:
 	choose row MonsterID from Table of Random Critters;
 	setmonster "Chinchilla";
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
-	else if "Female Preferred" is listed in feats of Player:
-		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";
 	else:

--- a/Guest Writers/Pit Bull.i7x
+++ b/Guest Writers/Pit Bull.i7x
@@ -334,7 +334,7 @@ name(text)	PrepFunction(text)
 
 to say PrepCombat_Pit Bull:
 	choose row MonsterID from the Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Kernog/Monkey King.i7x
+++ b/Kernog/Monkey King.i7x
@@ -133,7 +133,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Monkey:
 	setmongender 3; [creature is male]
 	choose row MonsterID from the Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Luneth/Frank.i7x
+++ b/Luneth/Frank.i7x
@@ -540,7 +540,7 @@ to say maleskunkinfect:
 				break;
 		now sex entry is "Male"; [Temporarily forced to 'Male'... will result in no gender change occurring if F-Pref]
 		infect "Skunkbeast Lord";
-		if "Female Preferred" is listed in feats of Player:
+		if Player is FemalePreferred:
 			now sex entry is "Female";
 		else if "Herm Preferred" is listed in feats of Player:
 			now sex entry is "Both";

--- a/Luneth/Icarus.i7x
+++ b/Luneth/Icarus.i7x
@@ -1239,7 +1239,7 @@ to say icarussex0_sub_m:
 to Icarusinfect:
 	setmonster "Blue Chaffinch";
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Nuku Valente/Latex Fox.i7x
+++ b/Nuku Valente/Latex Fox.i7x
@@ -90,7 +90,7 @@ to say PrepCombat_Latex Fox:
 	setmongender 3; [creature is male]
 	project Figure of LatexFox_soft_icon;
 	choose row MonsterID from Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Nuku Valente/Naga.i7x
+++ b/Nuku Valente/Naga.i7x
@@ -125,9 +125,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Naga:
 	setmongender 3; [creature is male]
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
-		now sex entry is "Male";
-	else if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Nuku Valente/Otter.i7x
+++ b/Nuku Valente/Otter.i7x
@@ -136,7 +136,7 @@ name(text)	PrepFunction(text)
 
 to say PrepCombat_Sea Otter:
 	choose row MonsterID from Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Nuku Valente/Slutrat.i7x
+++ b/Nuku Valente/Slutrat.i7x
@@ -211,7 +211,7 @@ this is the rattymilk rule:
 		now dam is (dam * 150) divided by 100;
 		say ". You end up getting a very large dose of her milk before you are able to push away - Critical Hit";
 	say "! You take [special-style-2][dam][roman type] damage";
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		say ". You can feel a tingling in your groin that starts to flare up, but is then resisted until it subsides.";
 	else if Ball Size of Player > 0 and Ball Size of Player < 4:
 		BallsGrow Player by 1;
@@ -297,7 +297,7 @@ to say slut rat victory:
 
 
 To say slut rat growth:
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		say "You resist the growth!";
 	else if Player is not male:
 		now Cock Count of Player is 1;

--- a/Sarokcat/Harold.i7x
+++ b/Sarokcat/Harold.i7x
@@ -296,7 +296,7 @@ to unicornify:
 		if Name entry is "Unicorn":
 			now MonsterID is y;
 			break;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/StripeGuy/Yuppie Mink.i7x
+++ b/StripeGuy/Yuppie Mink.i7x
@@ -109,12 +109,12 @@ to say PrepCombat_Yuppie Mink:
 		setmongender 4; [creature is female]
 		project figure of YuppieMink_icon;
 		now sex entry is "Male";
-		if "Female Preferred" is listed in the feats of Player, now sex entry is "Female";
+		if Player is FemalePreferred, now sex entry is "Female";
 	else if ymgmode is 2:
 		setmongender 3; [creature is male]
 		project figure of YuppieMink_M_clothed_icon;
 		now sex entry is "Female";
-		if "Male Preferred" is listed in the feats of Player, now sex entry is "Male";
+		if Player is MalePreferred, now sex entry is "Male";
 
 Table of Random Critters (continued)
 NewTypeInfection (truth state)	Species Name	Name	Enemy Title	Enemy Name	Enemy Type	Attack	Defeated	Victory	Desc	Face	Body	Skin	Tail	Cock	Face Change	Body Change	Skin Change	Ass Change	Cock Change	str	dex	sta	per	int	cha	sex	HP	lev	wdam	area	Cock Count	Cock Length	Ball Size	Nipple Count	Breast Size	Male Breast Size	Cunt Count	Cunt Depth	Cunt Tightness	SeductionImmune	Libido	Loot	Lootchance	TrophyFunction	MilkItem	CumItem	Scale (number)	Body Descriptor (text)	Type (text)	Magic (truth state)	Resbypass (truth state)	non-infectious (truth state)	Cross-Infection (text)	DayCycle	Altcombat (text)	BannedStatus (truth state)

--- a/Stripes/Anastasia.i7x
+++ b/Stripes/Anastasia.i7x
@@ -615,7 +615,7 @@ to Anastasiasexchange:
 			now MonsterID is y;
 			break;
 	choose row MonsterID from Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 		if Cunt Depth of Player < Cunt Depth entry and scenario is not "Researcher", follow the sex change rule;
 	else if "Herm Preferred" is listed in feats of Player:

--- a/Stripes/Automaton.i7x
+++ b/Stripes/Automaton.i7x
@@ -81,12 +81,12 @@ to say PrepCombat_Automaton:
 	if autogender is 1:		[male]
 		setmongender 3;
 		now sex entry is "Female";
-		if "Male Preferred" is listed in the feats of Player, now sex entry is "Male";
+		if Player is MalePreferred, now sex entry is "Male";
 		now lootchance entry is 33;
 	else:
 		setmongender 4; [female]
 		now sex entry is "Male";
-		if "Female Preferred" is listed in the feats of Player, now sex entry is "Female";
+		if Player is FemalePreferred, now sex entry is "Female";
 		now lootchance entry is 0;
 
 Table of Random Critters (continued)

--- a/Stripes/Bald Eagle.i7x
+++ b/Stripes/Bald Eagle.i7x
@@ -129,7 +129,7 @@ name(text)	PrepFunction(text)
 
 to say PrepCombat_Bald Eagle:
 	choose row MonsterID from Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Blue Chaffinch.i7x
+++ b/Stripes/Blue Chaffinch.i7x
@@ -214,7 +214,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Blue Chaffinch:
 	setmongender 3; [creature is male]
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/CandyShop.i7x
+++ b/Stripes/CandyShop.i7x
@@ -109,7 +109,7 @@ to say Sweet Tooth scene:
 	else if ferretvisit is 1:
 		[puts Sugar Ferret as lead monster for impregnation]
 		choose row with name of "Sugar Ferret" in Table of Random Critters;
-		if "Female Preferred" is listed in feats of Player:
+		if Player is FemalePreferred:
 			now sex entry is "Female";
 		else if "Herm Preferred" is listed in feats of Player:
 			now sex entry is "Both";
@@ -168,7 +168,7 @@ to say Sweet Tooth scene:
 	else:
 		[puts Sugar Ferret as lead monster for impregnation]
 		setmonster "Sugar Ferret";
-		if "Female Preferred" is listed in feats of Player:
+		if Player is FemalePreferred:
 			now sex entry is "Female";
 		else if "Herm Preferred" is listed in feats of Player:
 			now sex entry is "Both";

--- a/Stripes/Clockwork Fox.i7x
+++ b/Stripes/Clockwork Fox.i7x
@@ -134,13 +134,13 @@ to say cfgdesc:
 		setmongender 4; [creature is female]
 		say "     Before you is one of the most unusual forms the infection has taken, a wholly mechanical fox-creature. Looking over this clockwork fox girl, her body is made from metal segments and brass wire fur, which covers the internal mechanics of tiny metal gears. She whirrs and clicks as she moves in a jerking, hesitant manner, occasionally twitching as something catches in her gears for a few seconds. Her head is drawn forward into a muzzle, and the pointed, brass ears at the top give it a very foxy look. The anthro's body is thin and shapely, not dissimilar to the other vulpines you've seen in the city, but it's also covered in plated sections and protrusions of gears. Her chestplate has two small breasts formed onto it, her arms and legs are thin and vulpine, leading down to small, clawed paws, and she has a long plumed tail that seems to be made from extremely soft wire. The tail moves with the faint clicks of cogs and gears. A private peek reveals that she has a thick-lipped cunt nestled between her legs, made of shimmering, coppery flesh. It drips a clear lubricant, that glistens like oil, as the female mechanism moves forward to attack you.";
 		now sex entry is "Male";
-		if "Female Preferred" is listed in the feats of Player, now sex entry is "Female";
+		if Player is FemalePreferred, now sex entry is "Female";
 		if "Herm Preferred" is listed in the feats of Player, now sex entry is "Both";
 	else if cfgmode is 2:	[male]
 		setmongender 3; [creature is male]
 		say "     Before you is one of the most unusual forms the infection has taken, creating a wholly mechanical fox-creature. Looking over this clockwork fox guy, his body is made from metal segments and brass wire fur, covering internal mechanics of tiny metal gears. He whirrs and clicks as he moves in a slightly odd manner, occasionally twitching as something internal catches before releasing a moment later. His head is drawn forward into a muzzle, and the pointed, brass ears at the top give it a very foxy look. The anthro's body is thin and shapely, not dissimilar to the other vulpines you've seen in the city, but it's also covered in plated sections and protrusions of gears. His segmented chestplate gleams brightly, as if polished brass. His arms and legs are thin and vulpine, leading down to small, clawed paws, and he has a long plumed tail that seems to be made from extremely soft wire. The tail moves with the faint clicks of cogs and gears. A private peek reveals that he has a long, knotted cock made of coppery flesh, and it appears to be driven by a clockwork mechanism. It leaks a clear lubricant, that glistens like oil, as the male mechanism moves forward to attack you.";
 		now sex entry is "Female";
-		if "Male Preferred" is listed in the feats of Player, now sex entry is "Male";
+		if Player is MalePreferred, now sex entry is "Male";
 		if "Herm Preferred" is listed in the feats of Player, now sex entry is "Both";
 
 Table of CombatPrep (continued)

--- a/Stripes/Corota.i7x
+++ b/Stripes/Corota.i7x
@@ -51,7 +51,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Corota:
 	setmongender 4; [creature is female]
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Corrupted Spawner.i7x
+++ b/Stripes/Corrupted Spawner.i7x
@@ -133,7 +133,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Corrupted Spawner:
 	setmongender 4; [creature is female]
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Elk.i7x
+++ b/Stripes/Elk.i7x
@@ -159,7 +159,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Elk:
 	setmongender 3; [creature is male]
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";
@@ -363,7 +363,7 @@ to say elkantleruse:
 	say "     Looking over the antler, you feel a strange compulsion that you don't resist[if Player is elkfaced and Player is male]. Placing the piece of horn against one of your own antlers, there is a strange, crunchy sound as they fuse together. This is soon followed by the tingle of the nanites spreading through you[else]. Placing the piece of horn against the side of your head, there is a strange, crunching sound as they fuse together. You can feel the bony chunk sinking into you even as the tingles of nanites begin[end if].";
 	setmonster "Elk";
 	choose row MonsterID from the Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Fennec.i7x
+++ b/Stripes/Fennec.i7x
@@ -123,7 +123,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Fennec:
 	setmongender 3; [creature is male]
 	choose row MonsterID from Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";
@@ -324,7 +324,7 @@ to say drinkfennecsemen:
 		if Name entry is "Fennec":
 			now MonsterID is y;
 			break;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Horny Doctor.i7x
+++ b/Stripes/Horny Doctor.i7x
@@ -273,11 +273,11 @@ to say PrepCombat_Horny Doctor:
 		setmongender 4; [creature is female]
 		now altcombat entry is "default";
 	now BannedStatus entry is false;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";
-	else if "Male Preferred" is listed in feats of Player:
+	else if Player is MalePreferred:
 		now sex entry is "Male";
 	else if hdmode is 1:
 		now sex entry is "Female";

--- a/Stripes/Junkman.i7x
+++ b/Stripes/Junkman.i7x
@@ -47,7 +47,7 @@ to say PrepCombat_Junkman:
 		now wdam entry is qq;
 		now lev entry is qq;
 		now dex entry is ( qq + 10 + a random number between 0 and 2 );
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Komodo Dragon.i7x
+++ b/Stripes/Komodo Dragon.i7x
@@ -74,9 +74,9 @@ to say PrepCombat_Komodo Dragon:
 	project Figure of Komodo_Dragon_soft_icon;
 	setmongender 3; [creature is male]
 	choose row MonsterID from Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
-	else if "Male Preferred" is listed in feats of Player:
+	else if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Latex Ermine.i7x
+++ b/Stripes/Latex Ermine.i7x
@@ -95,7 +95,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Latex Ermine:
 	setmongender 4; [creature is female]
 	choose row MonsterID from Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Museum Rounds.i7x
+++ b/Stripes/Museum Rounds.i7x
@@ -302,7 +302,7 @@ to say mrevent08:
 			setmonster "Clockwork Fox";
 			choose row MonsterID from the Table of Random Critters;
 			now sex entry is "Female";
-			if "Male Preferred" is listed in the feats of Player, now sex entry is "Male";
+			if Player is MalePreferred, now sex entry is "Male";
 			if "Herm Preferred" is listed in the feats of Player, now sex entry is "Both";
 			say "     The clockwork fox guy runs his paws over your [bodydesc of Player] body, caressing and cuddling you. His motions are smooth and precise thanks to his recent oiling, only soft whirrs and clicks as the gears move inside him. His cool muzzle slides across your neck, giving you soft nips as he helps you out of your gear and guides you to one of the workbenches. Val gives you a quick wave and tells you to have fun, though you have little chance to respond before the fox's muzzle is pressed to your lips in a kiss. A curved brass tongue slides out to brush across yours while the lustful tod [if Player is female]dips a pair of fingers into your pussy[else]grabs your ass and fingers your tight pucker[end if]. Once the kiss is broken, the fox gets you to lean over the bench, chirring in a soft, musically chiming voice about how he'll give you a winding you'll never forget.";
 			say "     The brassworks fox runs his paws down your back and grabs your ass as he moves to get his mechanical cock lined up with your [if Player is female]juicy pussy[else]puckered hole[end if]. He starts slow, letting his cool, brass erection brush against you a few times so it may leak its oily precum onto it. His paws wander back up your [bodytype of Player] body as he thrusts into you with a happy chiming. The brass rod warms up quickly as he pumps into you, making you moan in pleasure. His oily pre leaks into you, making the metallic flesh's passing smooth and sensual.";
@@ -341,7 +341,7 @@ to say mrevent08:
 			setmonster "Clockwork Fox";
 			choose row MonsterID from the Table of Random Critters;
 			now sex entry is "Male";
-			if "Female Preferred" is listed in the feats of Player, now sex entry is "Female";
+			if Player is FemalePreferred, now sex entry is "Female";
 			if "Herm Preferred" is listed in the feats of Player, now sex entry is "Both";
 			say "     The clockwork fox girl runs her paws over your [bodydesc of Player] body, caressing and cuddling you. Her motions are smooth and precise thanks to her recent oiling, only soft whirrs and clicks as the gears move inside her. Her cool muzzle slides across your neck, giving you soft nips as she helps you out of your gear and tugs you over to one of the workbenches. Val gives you a quick wave and tells you to have fun, though you have little chance to respond before the vixen's muzzle is pressed to your lips in a kiss. A curved brass tongue slides out to brush across yours while the lustful fox girl [if Player is female]dips a pair of fingers into your pussy[else]takes hold of your cock and strokes it[end if]. Once the kiss is broken, the fox gets you to lean over the bench, chirring in a soft, musically chiming voice about how she [if Player is male]wants you to wind her so tight she'll scream when her mainspring pops[else]wants you to get her pussy nice and lubed up so one of the tods can wind her up[end if].";
 			if Player is male:

--- a/Stripes/Ocelot.i7x
+++ b/Stripes/Ocelot.i7x
@@ -330,7 +330,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Ocelot:
 	setmongender 3; [creature is male]
 	choose row MonsterID from the Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Siren.i7x
+++ b/Stripes/Siren.i7x
@@ -101,7 +101,7 @@ to say PrepCombat_Siren:
 	setmongender 3; [creature is male]
 	project Figure of Siren_clothed_icon;
 	choose row MonsterID from the Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Skunkbeast Lord.i7x
+++ b/Stripes/Skunkbeast Lord.i7x
@@ -363,7 +363,7 @@ to sblinfect:
 		if Name entry is "Skunkbeast Lord":
 			now MonsterID is y;
 			break;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Snake.i7x
+++ b/Stripes/Snake.i7x
@@ -220,9 +220,9 @@ to say PrepCombat_Snake:
 	choose row MonsterID from the Table of Random Critters;
 	if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";
-	else if "Male Preferred" is listed in feats of Player:
+	else if Player is MalePreferred:
 		now sex entry is "Male";
-	else if "Female Preferred" is listed in feats of Player:
+	else if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if Player is herm:
 		now sex entry is "Both";

--- a/Stripes/Snow Bat.i7x
+++ b/Stripes/Snow Bat.i7x
@@ -90,7 +90,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Snow Bat:
 	setmongender 3; [creature is male]
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Snow Leopard.i7x
+++ b/Stripes/Snow Leopard.i7x
@@ -164,7 +164,7 @@ to say PrepCombat_Snow Leopard:
 	project Figure of SnowLeopard_soft_icon;
 	setmongender 3; [creature is male]
 	choose row MonsterID from Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Squire.i7x
+++ b/Stripes/Squire.i7x
@@ -258,7 +258,7 @@ to say PrepCombat_Squire:
 	setmongender 3; [creature is male]
 	now kpstatus is 0;
 	choose row MonsterID from Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Stuck Dragon.i7x
+++ b/Stripes/Stuck Dragon.i7x
@@ -232,7 +232,7 @@ to say dragonesssex:
 		now lastChristyfucked is turns;
 	else if Cock Length of Player < 5:
 		say "     Your cock is too small for you to get it deep enough into her huge vagina to stimulate her or to get an enjoyable fuck from it. You sigh a little disappointment and decide to come back later after finding some means to";
-		if "Female Preferred" is not listed in feats of Player:
+		if Player is not FemalePreferred:
 			say " increase your maleness so you can come back and fuck this fine dragoness.";
 		else:
 			say " finish becoming a female to avoid the distraction of a cock you can't use to fuck this fine dragoness.";

--- a/Stripes/Sugar Ferret.i7x
+++ b/Stripes/Sugar Ferret.i7x
@@ -80,7 +80,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Sugar Ferret:
 	setmongender 19; [creatures are mixed/variable]
 	choose row MonsterID from Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Trash Coon.i7x
+++ b/Stripes/Trash Coon.i7x
@@ -60,7 +60,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Trash Coon:
 	setmongender 4; [creature is female]
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Voodoo Gecko.i7x
+++ b/Stripes/Voodoo Gecko.i7x
@@ -190,7 +190,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Voodoo Gecko:
 	setmongender 6; [creature is shemale]
 	choose row MonsterID from the Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";
@@ -392,7 +392,7 @@ to say drinkgeckocum:
 	increase Libido of Player by 5;
 	setmonster "Voodoo Gecko";
 	choose row MonsterID from the Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Stripes/Vulpogryph.i7x
+++ b/Stripes/Vulpogryph.i7x
@@ -23,7 +23,7 @@ name(text)	PrepFunction(text)
 
 to say PrepCombat_Vulpogryph:
 	choose row MonsterID from the Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 		now libido entry is 45;
 	else if "Herm Preferred" is listed in feats of Player:
@@ -220,7 +220,7 @@ to vulpogryphinfect:			[Solstice's magic infection bypasses researcher immunity]
 		if Name entry is "Vulpogryph":
 			now MonsterID is y;
 			break;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 		now libido entry is 45;
 	else if "Herm Preferred" is listed in feats of Player:

--- a/Stripes/Werewolf Costume.i7x
+++ b/Stripes/Werewolf Costume.i7x
@@ -53,7 +53,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Werewolf Costume:
 	setmongender 3; [creature is male]
 	choose row MonsterID from Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/UrsaOmega/Impala.i7x
+++ b/UrsaOmega/Impala.i7x
@@ -139,7 +139,7 @@ to say impaladesc:
 			say "and her eyes are filled with confusion as she tries to figure out which gender you are. 'What kind of creature are you?'";
 		say " the impala woman exclaims. She rubs a perky breast with one hoof-like hand while the other reaches down between her legs to play with her engorged sex a bit before charging you!";
 		now sex entry is "Male";
-		if "Female Preferred" is listed in the feats of Player, now sex entry is "Female";
+		if Player is FemalePreferred, now sex entry is "Female";
 		if "Herm Preferred" is listed in the feats of Player, now sex entry is "Both";
 	if impalamode is 1:
 		setmongender 3; [creature is male]
@@ -152,7 +152,7 @@ to say impaladesc:
 			say "and his eyes are filled with confusion as he tries to figure out which gender you are. 'What kind of creature are you?'[run paragraph on]";
 		say " the impala man exclaims. He charges you!";
 		now sex entry is "Female";
-		if "Male Preferred" is listed in the feats of Player, now sex entry is "Male";
+		if Player is MalePreferred, now sex entry is "Male";
 		if "Herm Preferred" is listed in the feats of Player, now sex entry is "Both";
 
 Section 2 - Creature Insertion

--- a/Voidsnaps/Knight.i7x
+++ b/Voidsnaps/Knight.i7x
@@ -34,7 +34,7 @@ playercrestnum is a number that varies. playercrestnum is usually 0.
 to say knightdesc:
 	[Sets target gender of Knight infection according to Player preferences]
 	choose row MonsterID from Table of Random Critters;
-	if "Female Preferred" is listed in feats of Player:
+	if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Wahn/Coyote.i7x
+++ b/Wahn/Coyote.i7x
@@ -211,9 +211,9 @@ to Coyotify: [Used for infection purposes.]
 			break;
 	if diego's heirloom collar is equipped:
 		now sex entry is "Female";
-	else if "Male Preferred" is listed in feats of Player:
+	else if Player is MalePreferred:
 		now sex entry is "Male";
-	else if "Female Preferred" is listed in feats of Player:
+	else if Player is FemalePreferred:
 		now sex entry is "Female";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";

--- a/Xenophiliac/Foul Scuttler.i7x
+++ b/Xenophiliac/Foul Scuttler.i7x
@@ -144,7 +144,7 @@ name(text)	PrepFunction(text)
 to say PrepCombat_Foul Scuttler: [pre-combat setup, run code and picture displays here]
 	setmongender 3; [creature is male]
 	choose row MonsterID from Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";
@@ -374,7 +374,7 @@ to say FoulScuttlerUse:
 	say "     You look disgustingly at the goopy liquid in the jar, wondering if you're insane for doing this. Steeling yourself, you bring the jar to your lips, quickly drinking the Foul Scuttler saliva. Contrary to your belief, the fluid does not taste horrendous, but it's not exactly tasty, either. Soon enough, you've drained the jar, putting it back into your pack for later use.";
 	setmonster "Foul Scuttler";
 	choose row MonsterID from the Table of Random Critters;
-	if "Male Preferred" is listed in feats of Player:
+	if Player is MalePreferred:
 		now sex entry is "Male";
 	else if "Herm Preferred" is listed in feats of Player:
 		now sex entry is "Both";


### PR DESCRIPTION
The second batch transitions code that tries to match target sex for infections to a player's preferences. There are no other changes in the PR.

Currently, a character with a locked sex (single-sex with a pure sex) will get targeted by invalid TFs, whereas characters with the old Preferred feats are accounted for. Since the feats (Single Sexed and Preferred) are exclusive, this updates the code to test the adjectives which cover both situations instead of just feat checking.

This covers most of the code that is currently deficient for gender-locked characters. There are still some instances of Preferred feat checking, but those are places where there are additional problems to hit or where there is no actual effect (either they can't be the tested gender, so the adjective would prove nothing, or they're combined with additional checks that negate any point in switching).