### PR TITLE
Add gender sanity checking to aftermath

### DIFF
--- a/Core Mechanics/Basic Functions.i7x
+++ b/Core Mechanics/Basic Functions.i7x
@@ -415,7 +415,7 @@ to playernaming:
 	say "Note: You can always change your name at a later point with the 'rename' command.";
 	say "     [bold type]Please enter your new name: [roman type][line break]";
 	get typed command as playerinput;
-	now name of Player is playerinput;
+	if "[playerinput]" is not "", now name of Player is playerinput;
 
 understand "observe" as ObserveRoom.
 understand "observe room" as ObserveRoom.
@@ -556,7 +556,7 @@ to NPCSexAftermath (TakingChar - a person) receives (SexAct - a text) from (Givi
 			say "DEBUG -> Player is the giving partner for '[SexAct]'[line break]";
 		if PlayerFucked of TakingChar is false: [player never had sex with this NPC]
 			now PlayerFucked of TakingChar is true; [player sexed up this NPC]
-		if SexAct is "AssFuck":
+		if SexAct is "AssFuck" and Player is male:
 			if PenileVirgin of Player is true:
 				now PenileVirgin of Player is false;
 				say "     [Bold Type]You have lost your penile virginity fucking [TakingChar]![roman type][line break]";
@@ -567,7 +567,7 @@ to NPCSexAftermath (TakingChar - a person) receives (SexAct - a text) from (Givi
 			increase AssFuckGiven of Player by 1;
 			if GivingChar is not sterile and TakingChar is mpreg_able: [mpreg fertile]
 				say "[ImpregFunction of TakingChar]";
-		else if SexAct is "PussyFuck":
+		else if SexAct is "PussyFuck" and Player is male:
 			if PenileVirgin of Player is true:
 				now PenileVirgin of Player is false;
 				say "     [Bold Type]You have lost your penile virginity fucking [TakingChar]![roman type][line break]";
@@ -590,13 +590,13 @@ to NPCSexAftermath (TakingChar - a person) receives (SexAct - a text) from (Givi
 				say "     [Bold Type]You have taken [TakingChar]'s anal virginity![roman type][line break]";
 				add printed name of TakingChar to AnalVirginitiesTaken of Player;
 			increase AssFuckGiven of Player by 1;
-		else if SexAct is "OralCock":
+		else if SexAct is "OralCock" and Player is male:
 			if OralVirgin of TakingChar is true:
 				now OralVirgin of TakingChar is false;
 				say "     [Bold Type]You have taken [TakingChar]'s oral virginity![roman type][line break]";
 				add printed name of TakingChar to OralVirginitiesTaken of Player;
 			increase OralCockGiven of Player by 1;
-		else if SexAct is "OralPussy":
+		else if SexAct is "OralPussy" and Player is female:
 			if OralVirgin of TakingChar is true:
 				now OralVirgin of TakingChar is false;
 				say "     [Bold Type]You have taken [TakingChar]'s oral virginity![roman type][line break]";
@@ -632,7 +632,7 @@ to NPCSexAftermath (TakingChar - a person) receives (SexAct - a text) from (Givi
 						<set the GivingChar as father somehow>
 					]
 			increase AssFuckTaken of Player by 1;
-		else if SexAct is "PussyFuck":
+		else if SexAct is "PussyFuck" and Player is female:
 			if debug is at level 1:
 				say "DEBUG -> MainInfection of [GivingChar] is '[MainInfection of GivingChar]'[line break]";
 			if Virgin of Player is true:
@@ -657,7 +657,7 @@ to NPCSexAftermath (TakingChar - a person) receives (SexAct - a text) from (Givi
 				say "     [Bold Type]You have lost your anal virginity to [GivingChar]![roman type][line break]";
 				now FirstAnalPartner of Player is printed name of GivingChar;
 			increase AssFuckTaken of Player by 1;
-		else if SexAct is "PussyDildoFuck": [used for dildos, fingers, tentacles - anything pussy penetrative that does not impregnate]
+		else if SexAct is "PussyDildoFuck" and Player is female: [used for dildos, fingers, tentacles - anything pussy penetrative that does not impregnate]
 			if Virgin of Player is true:
 				now Virgin of Player is false;
 				say "     [Bold Type]You have lost your virginity to [GivingChar]![roman type][line break]";
@@ -759,7 +759,7 @@ to CreatureSexAftermath (TakingCharName - a text) receives (SexAct - a text) fro
 			choose a row with name of TakingCharName in the Table of Random Critters;
 		else: [lets tell people to report this too]
 			say "     < ERROR: [TakingCharName] not found in Table of Random Critters. Please report the situation you saw this in on the Flexible Survival Discord Bug Report Channel! >";
-		if SexAct is "AssFuck":
+		if SexAct is "AssFuck" and Player is male:
 			if PenileVirgin of Player is true:
 				now PenileVirgin of Player is false;
 				say "     [Bold Type]You have lost your penile virginity fucking the [TakingCharName in lower case]![roman type][line break]";
@@ -775,7 +775,7 @@ to CreatureSexAftermath (TakingCharName - a text) receives (SexAct - a text) fro
 					now MainInfection of Impregnated Feral is TakingCharName; [saving the infection name]
 					if debugactive is 1:
 						say "DEBUG -> Non-Sterile Player succeeded in their [2 + Ball Size of Player] in 10 impregnation check. [Libido of Impregnated Feral] turns to birth of a [MainInfection of Impregnated Feral] offspring.[line break]";
-		else if SexAct is "PussyFuck":
+		else if SexAct is "PussyFuck" and Player is male:
 			if PenileVirgin of Player is true:
 				now PenileVirgin of Player is false;
 				say "     [Bold Type]You have lost your penile virginity fucking the [TakingCharName in lower case]![roman type][line break]";
@@ -795,9 +795,9 @@ to CreatureSexAftermath (TakingCharName - a text) receives (SexAct - a text) fro
 			increase AssFuckGiven of Player by 1;
 		else if SexAct is "PussyDildoFuck": [used for dildos, fingers, tentacles - anything pussy penetrative that does not impregnate]
 			increase PussyFuckGiven of Player by 1;
-		else if SexAct is "OralCock":
+		else if SexAct is "OralCock" and Player is male:
 			increase OralCockGiven of Player by 1;
-		else if SexAct is "OralPussy":
+		else if SexAct is "OralPussy" and Player is female:
 			increase OralPussyGiven of Player by 1;
 	else if TakingCharName is "Player" or TakingCharName is "player":
 		if debugactive is 1:
@@ -813,7 +813,7 @@ to CreatureSexAftermath (TakingCharName - a text) receives (SexAct - a text) fro
 			else:
 				mimpregchance;
 			increase AssFuckTaken of Player by 1;
-		else if SexAct is "PussyFuck":
+		else if SexAct is "PussyFuck" and Player is female:
 			if Virgin of Player is true:
 				now Virgin of Player is false;
 				say "     [Bold Type]You have lost your virginity to the [GivingCharName in lower case]![roman type][line break]";
@@ -830,7 +830,7 @@ to CreatureSexAftermath (TakingCharName - a text) receives (SexAct - a text) fro
 				say "     [Bold Type]You have lost your anal virginity to [GivingCharName]![roman type][line break]";
 				now FirstAnalPartner of Player is GivingCharName;
 			increase AssFuckTaken of Player by 1;
-		else if SexAct is "PussyDildoFuck":
+		else if SexAct is "PussyDildoFuck" and Player is female:
 			if Virgin of Player is true:
 				now Virgin of Player is false;
 				say "     [Bold Type]You have lost your virginity to [GivingCharName]![roman type][line break]";


### PR DESCRIPTION
The aftermath functions currently operate regardless of whether it even makes sense to do so. This just adds checks to the acts to make sure that the player has the required genitalia before executing (if not, it will just do nothing silently). (These will always be from bugs in the scenes where they were improperly applied, and should still be fixed there, but this ensures that they won't ever make it through to the player.)

These checks only operate against the player (giving and taking), for both NPC and creature aftermaths. Aftermaths targeting NPCs and/or creatures have no checks and will still operate on any input, whether it makes sense or not.

This commit also adjusts player renaming to require something to be entered before the name is changed (entering nothing or only spaces will no longer empty the player name). After the change, hitting enter without typing anything, or typing only spaces, will simply return and leave the existing name in place.